### PR TITLE
reindex items with odd ability/effect order

### DIFF
--- a/cdtweaks/lib/fj_spl_itm_reindex.tpa
+++ b/cdtweaks/lib/fj_spl_itm_reindex.tpa
@@ -1,0 +1,54 @@
+DEFINE_PATCH_FUNCTION ~FJ_SPL_ITM_REINDEX~ BEGIN
+
+  PATCH_IF !(~%SOURCE_FILE%~ STRING_MATCHES_REGEXP ~^.+\.spl~) BEGIN
+    hs = 0x28
+    WRITE_LONG 0xc ~-1~ //Identified name
+    WRITE_LONG 0x54 ~-1~ //Identified description
+    PATCH_FOR_EACH tz IN 0x44 0x48 0x58 0x5c BEGIN
+      WRITE_LONG tz 0
+    END
+  END ELSE PATCH_IF !(~%SOURCE_FILE%~ STRING_MATCHES_REGEXP ~^.+\.itm~) BEGIN
+    hs = 0x38
+  END
+  READ_LONG  0x64 hf //Extended header offset
+  READ_SHORT 0x68 hc //Extended header count
+  READ_LONG  0x6a fb //Feature block table offset
+  READ_SHORT 0x70 fc //Feature block count
+  
+  // position abilities before effects
+  PATCH_IF ((hf > fb) AND (hc > 0)) BEGIN // Ardanis: fixed "hc > 1" to "hc > 0"
+    READ_ASCII hf ~eh~ ELSE ~fail~ (hs * hc)
+    PATCH_IF (~%eh%~ STRING_EQUAL ~fail~) BEGIN
+      WHILE ((~%eh%~ STRING_EQUAL ~fail~) AND (hc > 0)) BEGIN
+        READ_ASCII hf ~eh~ ELSE ~fail~ (hs * hc)
+        hc -= 1
+      END
+    END
+    DELETE_BYTES hf (hs * hc)
+    hf = 0x72
+    WRITE_LONG 0x64 hf
+    WRITE_SHORT 0x68 hc
+    fb = (0x72 + (hs * hc))
+    WRITE_LONG 0x6a fb
+    PATCH_IF !(~%eh%~ STRING_EQUAL ~fail~) BEGIN
+      INSERT_BYTES hf (hs * hc)
+      WRITE_ASCIIE hf ~%eh%~
+    END
+  END ELSE PATCH_IF ((hf != 0x72) AND (hc = 0)) BEGIN
+    hf = 0x72
+    WRITE_LONG 0x64 hf
+  END
+  
+  // global effects always go before features
+  FOR (i1 = 0; i1 < (hs * hc); i1 += hs) BEGIN
+    WRITE_SHORT (hf + i1 + 0x20) fc
+    READ_SHORT (hf + i1 + 0x1e) cx
+    fc += cx
+  END
+  WRITE_SHORT 0x6e 0 // added by Ardanis
+  
+  PATCH_IF (SOURCE_SIZE > (0x72 + (hs * hc) + (0x30 * fc))) BEGIN
+    DELETE_BYTES (0x72 + (hs * hc) + (0x30 * fc)) (SOURCE_SIZE - (0x72 + (hs * hc) + (0x30 * fc)))
+  END
+
+END // end of function

--- a/cdtweaks/readme-cdtweaks.html
+++ b/cdtweaks/readme-cdtweaks.html
@@ -1703,6 +1703,10 @@
     <div class="ribbon_triangle_h2-l"></div>
     <div class="ribbon_triangle_h2-r"></div>
     <div class="section">
+      <p><strong>Version Beta 5 - July 27, 2016</strong></p>
+      <ul>
+        <li><strong>Wear Multiple Protection Items</strong> will no longer fail when patching items that have effects listed before abilities (thanks Nythrun, Ardanis, and Mike1072)</li>
+      </ul>
       <p><strong>Version Beta 4 - May 1, 2016</strong></p>
       <ul>
         <li><strong>Make Magic Shields Glow</strong> had two bugs preventing its installation; it would halt on games without an extended color palette (e.g. non-EE games or without 1pp) and would halt on shields without any colors set, such as IWD's Lyre of Progression</li>

--- a/cdtweaks/setup-cdtweaks.tp2
+++ b/cdtweaks/setup-cdtweaks.tp2
@@ -5594,6 +5594,7 @@ REQUIRE_PREDICATE NOT GAME_IS ~iwd2 pst~ @25
 SUBCOMPONENT @215000 // wear multiple protection items
 
 INCLUDE ~cdtweaks/lib/pnp_descripts.tpa~  // text replacement macros
+INCLUDE ~cdtweaks/lib/fj_spl_itm_reindex.tpa~
 
 // first, eliminate iwd items on list without AC bonuses
 COPY_EXISTING ~itemexcl.2da~ ~override~
@@ -5655,6 +5656,7 @@ COPY + ~override/cdpnp.2da~ ~cdtweaks/2da/cdpnp.2da~
       ACTION_IF FILE_EXISTS_IN_GAME ~%orig%.itm~ THEN BEGIN
 
         COPY_EXISTING ~%orig%.itm~ ~override~
+          LPF ~FJ_SPL_ITM_REINDEX~ END
           READ_ASCII  0x3a bam (8)
           READ_SHORT  0x42 lore
           PATCH_IF (lore = 0) BEGIN


### PR DESCRIPTION
to avoid mangling them in the component Wear Multiple Protection Items
-> P&P Restrictions