### PR TITLE
Checks not needed in BG2EE or EET

### DIFF
--- a/cdtweaks/setup-cdtweaks.tp2
+++ b/cdtweaks/setup-cdtweaks.tp2
@@ -80,7 +80,7 @@ LANGUAGE
   ~cdtweaks/languages/english/description_updates.tra~
   ~cdtweaks/languages/english/setup.tra~
 LANGUAGE
-  ~Czech (Translation by Razfallow and Vlas·k)~
+  ~Czech (Translation by Razfallow and Vlas√°k)~
   ~czech~
   ~cdtweaks/languages/english/setup.tra~
   ~cdtweaks/languages/czech/setup.tra~
@@ -6983,9 +6983,13 @@ END
 
 BEGIN @224000 DESIGNATED 2240
 GROUP @9
+
+ACTION_IF (!GAME_IS ~eet bg2ee~) BEGIN
 REQUIRE_PREDICATE NOT FILE_EXISTS_IN_GAME ~bpduearc.spl~ @16      // non-BP
 REQUIRE_PREDICATE NOT FILE_EXISTS         ~data/rot-rule.bif~ @16 // non-RoT
 REQUIRE_PREDICATE NOT FILE_EXISTS         ~data/tdd-rule.bif~ @16 // non-TDD
+END
+
 REQUIRE_PREDICATE NOT GAME_IS ~iwd2~ @25
 
 ACTION_IF GAME_IS ~iwd2~ THEN BEGIN


### PR DESCRIPTION
You surely have better code for it...just to illustrate the idea
The checks for RoT and TDD tables are only applicable for the non-EE versions. In EE the implementation of the tables is skipped.
However - at least - RoT leaves an empty bif-file as install marker for other mods. Of course that blocks tweaks components to install.

The proposed change would apply to these cdtweaks components 2240|2250|2260|2261|2270|2271|2280|2281|2290|2291

The whole background for the change request is here http://baldursextendedworld.com/Vanilla_Forums/discussion/354/tweaks-anthology-alter-mage-cleric-druid-tables#latest