### PR TITLE
Dynaheir/Xzar/Edwin Generalist Mage

### DIFF
--- a/cdtweaks/random/make_generalist.tpa
+++ b/cdtweaks/random/make_generalist.tpa
@@ -1,0 +1,30 @@
+DEFINE_PATCH_MACRO mh_make_generalist
+BEGIN
+  PATCH_IF (SOURCE_SIZE > 0x2d3)
+  BEGIN
+    WRITE_SHORT 0x246 0x4000 // change mage type to generalist mage
+    
+    // fix spell memorisation info
+    READ_BYTE 0x0234 mage_level
+
+    GET_OFFSET_ARRAY spell_mem_array CRE_V10_SPELL_MEM_INFO
+    PHP_EACH spell_mem_array AS spell_mem_no => spell_mem_offset
+    BEGIN
+      READ_SHORT (spell_mem_offset + 0x0000) spell_level
+      READ_SHORT (spell_mem_offset + 0x0006) spell_type
+
+      PATCH_IF (spell_type == 1)
+      BEGIN
+        INNER_PATCH_FILE "mxsplwiz.2da"
+	BEGIN
+	  READ_2DA_ENTRY (mage_level) (spell_level + 1) 9 max_spells
+	END
+
+        WRITE_SHORT (spell_mem_offset + 0x02) max_spells
+        WRITE_SHORT (spell_mem_offset + 0x04) max_spells
+      END
+    END
+  END
+END
+
+

--- a/cdtweaks/setup-cdtweaks.tp2
+++ b/cdtweaks/setup-cdtweaks.tp2
@@ -13895,6 +13895,7 @@ COPY_EXISTING_REGEXP GLOB ~^_?coran[0-9]*.*\.cre$~ ~override~
   WRITE_BYTE 0x23c 19 // 19 DEX
   BUT_ONLY_IF_IT_CHANGES
 
+
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////                                                  \\\\\
@@ -13907,50 +13908,69 @@ BEGIN @413000 DESIGNATED 4130
 GROUP @0
 REQUIRE_PREDICATE GAME_IS ~bg1 totsc tutu tutu_totsc bgt eet bgee~ @25 // Tutu or BGT only
 
-COPY_EXISTING_REGEXP GLOB ~^_?xan[46]?\.cre$~ ~override~
-  PATCH_IF (SOURCE_SIZE > 0x2d3) THEN BEGIN // protects against invalid files
-    WRITE_SHORT 0x246 16384 // change mage type to generalist mage
-    
-    // fix spell memorisation info
-    READ_BYTE 0x234 level
-    READ_LONG 0x2a8 mem_info_off
-    READ_LONG 0x2ac num_mem_info
-    FOR (i = 0; i < num_mem_info; i += 1) BEGIN
-      READ_SHORT (mem_info_off + 0x10*i) spell_level
-      READ_SHORT (mem_info_off + 0x10*i + 0x06) spell_type
-      PATCH_IF (level == 2) BEGIN // xan.cre
-        PATCH_IF (spell_type == 1 && spell_level == 0) BEGIN // wizard, level 1 spells
-          WRITE_SHORT (mem_info_off + 0x10*i + 0x02) 2
-          WRITE_SHORT (mem_info_off + 0x10*i + 0x04) 2
-        END
-      END ELSE
-      PATCH_IF (level == 4) BEGIN // xan4.cre
-        PATCH_IF (spell_type == 1 && spell_level == 0) BEGIN // wizard, level 1 spells
-          WRITE_SHORT (mem_info_off + 0x10*i + 0x02) 3
-          WRITE_SHORT (mem_info_off + 0x10*i + 0x04) 3
-        END ELSE
-        PATCH_IF (spell_type == 1 && spell_level == 1) BEGIN // wizard, level 2 spells
-          WRITE_SHORT (mem_info_off + 0x10*i + 0x02) 2
-          WRITE_SHORT (mem_info_off + 0x10*i + 0x04) 2
-        END
-      END ELSE
-      PATCH_IF (level == 6) BEGIN // xan6.cre
-        PATCH_IF (spell_type == 1 && spell_level == 0) BEGIN // wizard, level 1 spells
-          WRITE_SHORT (mem_info_off + 0x10*i + 0x02) 4
-          WRITE_SHORT (mem_info_off + 0x10*i + 0x04) 4
-        END ELSE
-        PATCH_IF (spell_type == 1 && spell_level == 1) BEGIN // wizard, level 2 spells
-          WRITE_SHORT (mem_info_off + 0x10*i + 0x02) 2
-          WRITE_SHORT (mem_info_off + 0x10*i + 0x04) 2
-        END ELSE
-        PATCH_IF (spell_type == 1 && spell_level == 2) BEGIN // wizard, level 3 spells
-          WRITE_SHORT (mem_info_off + 0x10*i + 0x02) 2
-          WRITE_SHORT (mem_info_off + 0x10*i + 0x04) 2
-        END
-      END
-    END
-  END
+ACTION_INCLUDE "cdtweaks/random/make_generalist.tpa"
+
+COPY_EXISTING_REGEXP "^_?xan[0-9]*.cre$" "override"
+  LAUNCH_PATCH_MACRO mh_make_generalist
   BUT_ONLY_IF_IT_CHANGES
+
+
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////                                                  \\\\\
+///// Make Dynaheir a Generalist Mage                  \\\\\
+/////                                                  \\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+
+BEGIN ~Make Dynaheir a Generalist Mage (Angel)~ DESIGNATED 4131
+GROUP @0
+REQUIRE_PREDICATE GAME_IS ~bg1 totsc tutu tutu_totsc bgt eet bgee~ @25 // Tutu or BGT only
+
+ACTION_INCLUDE "cdtweaks/random/make_generalist.tpa"
+
+COPY_EXISTING_REGEXP "^_?dynahe[0-9]*.cre$" "override"
+  LAUNCH_PATCH_MACRO mh_make_generalist
+  BUT_ONLY_IF_IT_CHANGES
+
+
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////                                                  \\\\\
+///// Make Xzar a Generalist Mage                      \\\\\
+/////                                                  \\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+
+BEGIN ~Make Xzar a Generalist Mage (Angel)~ DESIGNATED 4132
+GROUP @0
+REQUIRE_PREDICATE GAME_IS ~bg1 totsc tutu tutu_totsc bgt eet bgee~ @25 // Tutu or BGT only
+
+ACTION_INCLUDE "cdtweaks/random/make_generalist.tpa"
+
+COPY_EXISTING_REGEXP "^_?xzar[0-9]*.cre$" "override"
+  LAUNCH_PATCH_MACRO mh_make_generalist
+  BUT_ONLY_IF_IT_CHANGES
+
+
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////                                                  \\\\\
+///// Make Edwin a Generalist Mage                     \\\\\
+/////                                                  \\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+
+BEGIN ~Make Edwin a Generalist Mage (Angel)~ DESIGNATED 4133
+GROUP @0
+REQUIRE_PREDICATE GAME_IS ~bg1 totsc tutu tutu_totsc bg2 tob bgt eet bgee bg2ee~ @25 // All BG games
+
+ACTION_INCLUDE "cdtweaks/random/make_generalist.tpa"
+
+COPY_EXISTING_REGEXP "^_?edwin[0-9]*.cre$" "override"
+  LAUNCH_PATCH_MACRO mh_make_generalist
+  BUT_ONLY_IF_IT_CHANGES
+
 
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\


### PR DESCRIPTION
This revises the code for "Make Xan a Generalist Mage".  Code is modernized and streamlined, and now pulls the correct values from mxsplwiz.2da instead of using hardcoded ones, increasing compatibility.  

Dynaheir, Xzar and Edwin can now also be made generalists, for Edwin this also works in BG2.