### PR TITLE
Add convenience tweak 'Create interval saves'

### DIFF
--- a/cdtweaks/cdtweaks.disabled.txt
+++ b/cdtweaks/cdtweaks.disabled.txt
@@ -62,3 +62,36 @@ OUTER_SET minimum_stats_dexterity    = 0
 OUTER_SET minimum_stats_intelligence = 0
 OUTER_SET minimum_stats_wisdom       = 0
 OUTER_SET minimum_stats_charisma     = 0
+
+
+
+
+// The following variables will be used for the subcomponent "Create interval saves -> Customize":
+// Set this value to 1 to activate interval save. Set it to 0 to deactivate interval save. Default: 1
+OUTER_SET interval_save_enabled = 1
+
+// Set this value to the interval between saves (in seconds). Default: 1800 seconds (30 minutes)
+OUTER_SET interval_save_delay = 1800
+
+// Set this value to 1 to allow creating interval saves during combat. Set it to 0 to forbid
+// creating interval saves during combat. Default: 0
+OUTER_SET interval_save_combat = 0
+
+// Set this value to the number of save slots to cycle through. Up to 16 save slots are allowed.
+// This value is only considered for games patched to version 2.0 or later. Default: 1 slot
+OUTER_SET interval_save_count = 1
+
+// Set this value to 1 to use the custom "Interval-Save" slot whenever a save is created.
+// Set this value to 0 to use the "Auto-Save" slot instead. Custom save slots are enforced
+// if interval_save_count > 1. This value is only considered for games patched
+// to version 2.0 or later. Default: 1
+OUTER_SET interval_save_custom_slot = 1
+
+// Set this value to 1 to show a feedback message whenever an interval save is created.
+// Set it to 0 to suppress any feedback. Default: 1
+OUTER_SET interval_save_feedback = 1
+
+// Set this value to 1 to control interval save creation by Baldur.lua configuration options.
+// Set this value to 0 to enforce using game variables to control interval save creation.
+// This value is only considered for games patched to version 2.0 or later. Default: 1
+OUTER_SET interval_save_ini = 1

--- a/cdtweaks/languages/english/setup.tra
+++ b/cdtweaks/languages/english/setup.tra
@@ -1418,6 +1418,28 @@ This ability controls whether party members can move at increased speed outside 
 
 This ability controls whether party members can move at increased speed outside of combat. Click on the ability to turn it ON.~
 @333020 = ~Movement speed bonus removed~
+@335000 = ~Create interval saves~
+@335001 = ~Every 15 minutes (one save only)~
+@335002 = ~Every 30 minutes (one save only)~
+@335003 = ~Every 60 minutes (one save only)~
+@335004 = ~Every 120 minutes (one save only)~
+@335005 = ~Every 15 minutes (cycle through four saves)~
+@335006 = ~Every 30 minutes (cycle through four saves)~
+@335007 = ~Every 60 minutes (cycle through four saves)~
+@335008 = ~Every 120 minutes (cycle through four saves)~
+@335009 = ~Customize (via cdtweaks.txt)~
+@335100 = ~Interval-Save~
+@335101 = ~Interval save created~
+@335102 = ~Interval save (slot %slot_index%) created~
+@335103 = ~Interval save options:
+Enable interval save:   a7_interval_enable
+Interval between saves: a7_interval_delay seconds
+Save during combat:     a7_interval_combat
+Number of save slots:   a7_interval_slots
+Use custom save name:   a7_interval_custom
+Show feedback message:  a7_interval_feedback
+Use Baldur.lua options: a7_interval_ini
+~
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////                                                  \\\\\

--- a/cdtweaks/lib/interval_saves.tpa
+++ b/cdtweaks/lib/interval_saves.tpa
@@ -1,0 +1,245 @@
+// Create savegame entries
+DEFINE_ACTION_FUNCTION a7_append_savename
+INT_VAR
+  custom_slot = 0 // whether to use a custom save name (1) or re-use autosave (0)
+  count = 1       // number of subsaves to cycle through
+RET
+  slot            // initial save slot index
+BEGIN
+  OUTER_SET slot = 0
+  ACTION_IF (custom_slot || count > 1) BEGIN
+    COPY_EXISTING ~savename.2da~ ~override~
+      COUNT_2DA_COLS num_cols
+      PATCH_IF (num_cols >= 4) BEGIN
+        READ_2DA_ENTRIES_NOW table 1
+
+        // determine initial slot index
+        PATCH_IF (custom_slot || count > 1) BEGIN
+          SET slot = table - 3
+        END
+
+        // getting base savename
+        PATCH_IF (custom_slot) BEGIN
+          INNER_PATCH_SAVE prefix ~000000000~ BEGIN
+            WRITE_ASCIIE (BUFFER_LENGTH - STRING_LENGTH ~%slot%~) ~%slot%~
+          END
+          SPRINT base_name @335100  // Interval-Save
+          TEXT_SPRINT base_name ~%prefix%-%base_name%~
+        END ELSE BEGIN
+          // getting name of auto-save
+          READ_2DA_ENTRY_FORMER table 3 1 strref
+          GET_STRREF strref base_name
+        END
+      END
+    BUT_ONLY IF_EXISTS
+
+    // adding new save entries
+    ACTION_IF (slot > 0) BEGIN
+      OUTER_FOR (i = 1; i <= count; ++i) BEGIN
+        OUTER_SET idx = slot + i - 1
+        ACTION_IF (i > 1) BEGIN
+          OUTER_TEXT_SPRINT savename ~%base_name%-%i%~
+        END ELSE BEGIN
+          OUTER_TEXT_SPRINT savename ~%base_name%~
+        END
+        OUTER_SET strref = RESOLVE_STR_REF(~%savename%~)
+        OUTER_TEXT_SPRINT line ~%idx% %strref% %idx% 1~
+        APPEND ~savename.2da~ ~%line%~ IF_EXISTS
+      END
+      COPY_EXISTING ~savename.2da~ ~override~
+        PRETTY_PRINT_2DA
+      BUT_ONLY IF_EXISTS
+    END
+  END
+END
+
+
+// Expand global game scripts to save game in fixed intervals
+DEFINE_ACTION_FUNCTION a7_append_script
+INT_VAR
+  enabled  = 1    // whether interval save creation is enabled
+  combat   = 0    // whether interval saves can be created during combat
+  interval = 1800 // interval in seconds
+  slot     = 0    // initial save slot to use
+  count    = 1    // number of save slots to cycle through
+  feedback = 1    // whether to display a feedback message in the combat log
+  use_ini  = 1
+BEGIN
+  OUTER_SET IS_EE20 = (VALID_SCRIPT_TRIGGERS ~INI("IntervalSaveEnabled",0)~ && FILE_EXISTS_IN_GAME ~savename.2da~) ? 1 : 0
+
+  // getting list of world scripts
+  ACTION_FOR_EACH resref IN ~BALDUR~ ~BALDUR25~ ~BDBALDUR~ BEGIN
+    ACTION_IF (FILE_EXISTS_IN_GAME ~%resref%.BCS~) BEGIN
+      OUTER_SET $scripts(~%resref%~) = 1
+    END
+  END
+  COPY_EXISTING ~campaign.2da~ ~override~
+    READ_2DA_ENTRIES_NOW table 1
+    FOR (row = 3; row < table; ++row) BEGIN
+      READ_2DA_ENTRY_FORMER table row 1 resref
+      PATCH_IF (FILE_EXISTS_IN_GAME ~%resref%.BCS~) BEGIN
+        TO_UPPER ~resref~
+        SET $scripts(~%resref%~) = 1
+      END
+    END
+  BUT_ONLY IF_EXISTS
+
+  OUTER_TEXT_SPRINT baf ~~
+  ACTION_IF (IS_EE20 && use_ini) BEGIN
+    OUTER_TEXT_SPRINT IsIntervalSaveEnabled ~!INI("IntervalSaveEnabled",0)~
+    OUTER_TEXT_SPRINT IsIntervalSaveCombat ~!INI("IntervalSaveCombat",0)~
+    ACTION_IF (FILE_EXISTS ~%USER_DIRECTORY%/Baldur.lua~) BEGIN
+      APPEND_OUTER + ~%USER_DIRECTORY%/Baldur.lua~ ~SetPrivateProfileString('Script','IntervalSaveEnabled','%enabled%')~ UNLESS ~IntervalSaveEnabled~
+      APPEND_OUTER + ~%USER_DIRECTORY%/Baldur.lua~ ~SetPrivateProfileString('Script','IntervalSaveCombat','%combat%')~ UNLESS ~IntervalSaveCombat~
+    END ELSE BEGIN
+<<<<<<<< .../inlined/a7-intervalsave-baldur.lua
+SetPrivateProfileString('Script','IntervalSaveEnabled','1')
+SetPrivateProfileString('Script','IntervalSaveCombat','0')
+>>>>>>>>
+      COPY + ~.../inlined/a7-intervalsave-baldur.lua~ ~%USER_DIRECTORY%/Baldur.lua~
+    END
+  END ELSE BEGIN
+    OUTER_TEXT_SPRINT IsIntervalSaveEnabled ~!Global("A7-IntervalSaveEnabled","GLOBAL",0)~
+    OUTER_TEXT_SPRINT IsIntervalSaveCombat ~!Global("A7-IntervalSaveCombat","GLOBAL",0)~
+    OUTER_TEXT_SPRINT baf ~
+IF
+  Global("A7-IntervalSaveInit","GLOBAL",0)
+THEN
+  RESPONSE #100
+    SetGlobal("A7-IntervalSaveInit","GLOBAL",1)
+    SetGlobal("A7-IntervalSaveEnabled","GLOBAL",%enabled%)
+    SetGlobal("A7-IntervalSaveCombat","GLOBAL",%combat%)
+    Continue()
+END
+~
+  END
+
+  // generating script
+  OUTER_TEXT_SPRINT baf ~%baf%
+IF
+  %IsIntervalSaveEnabled%
+  Global("A7-IntervalSave","GLOBAL",1)
+THEN
+  RESPONSE #100
+    SetGlobal("A7-IntervalSave","GLOBAL",0)
+    RealSetGlobalTimer("A7-IntervalSaveTimer","GLOBAL",%interval%)
+    Continue()
+END
+~
+
+  OUTER_FOR (i = 0; i < count; ++i) BEGIN
+    // Save slot handling
+    OUTER_SET slot_number = IS_EE20 ? slot + i : 0
+    ACTION_IF (count = 1) BEGIN
+      OUTER_TEXT_SPRINT checkslot ~~
+    END ELSE ACTION_IF (i = 0) BEGIN
+      OUTER_TEXT_SPRINT checkslot ~GlobalLT("A7-IntervalSaveSlot","GLOBAL",1)~
+    END ELSE ACTION_IF (i = count - 1) BEGIN
+      OUTER_SET i_prev = i - 1
+      OUTER_TEXT_SPRINT checkslot ~GlobalGT("A7-IntervalSaveSlot","GLOBAL",%i_prev%)~
+    END ELSE BEGIN
+      OUTER_TEXT_SPRINT checkslot ~Global("A7-IntervalSaveSlot","GLOBAL",%i%)~
+    END
+    ACTION_IF (count = 1) BEGIN
+      OUTER_TEXT_SPRINT setslot ~~
+    END ELSE ACTION_IF (i < count - 1) BEGIN
+      OUTER_SET i_next = i + 1
+      OUTER_TEXT_SPRINT setslot ~SetGlobal("A7-IntervalSaveSlot","GLOBAL",%i_next%)~
+    END ELSE BEGIN
+      OUTER_TEXT_SPRINT setslot ~SetGlobal("A7-IntervalSaveSlot","GLOBAL",0)~
+    END
+
+    // Feedback message
+    ACTION_IF (feedback) BEGIN
+      ACTION_IF (NOT GAME_IS ~pstee~ &&
+                 FILE_EXISTS_IN_GAME ~util.lua~ &&
+                 FILE_CONTAINS_EVALUATED(~util.lua~ ~function[ %TAB%]+highlightString~)) BEGIN
+        OUTER_TEXT_SPRINT colorBegin ~^0xFF007F00~  // dark green
+        OUTER_TEXT_SPRINT colorEnd ~^-~
+      END ELSE BEGIN
+        OUTER_TEXT_SPRINT colorBegin ~~
+        OUTER_TEXT_SPRINT colorEnd ~~
+      END
+      ACTION_IF (count = 1) BEGIN
+        OUTER_SPRINT msg @335101 // Interval save created
+        OUTER_SET strref = RESOLVE_STR_REF(~%colorBegin%%msg%%colorEnd%~)
+      END ELSE BEGIN
+        OUTER_SET slot_index = i + 1
+        OUTER_SPRINT msg @335102 // Interval save (slot %slot_index%) created
+        OUTER_SET strref = RESOLVE_STR_REF(~%colorBegin%%msg%%colorEnd%~)
+      END
+      OUTER_TEXT_SPRINT feedback_msg ~DisplayStringNoName(Myself,%strref%)~
+    END ELSE BEGIN
+      OUTER_TEXT_SPRINT feedback_msg ~~
+    END
+
+    OUTER_TEXT_SPRINT baf ~%baf%
+IF
+  %IsIntervalSaveEnabled%
+  Global("A7-IntervalSave","GLOBAL",0)
+  %checkslot%
+  !RealGlobalTimerNotExpired("A7-IntervalSaveTimer","GLOBAL")
+  OR(2)
+    %IsIntervalSaveCombat%
+    CombatCounter(0)
+THEN
+  RESPONSE #100
+    SetGlobal("A7-IntervalSave","GLOBAL",1)
+    %setslot%
+    SaveGame(%slot_number%)
+    %feedback_msg%
+    Continue()
+END
+~
+  END
+
+  // appending scripts
+  ACTION_PHP_EACH scripts AS resref => _ BEGIN
+    ACTION_IF (NOT IS_EE20) BEGIN
+      // using hardcoded save slots for EE 1.x games
+      OUTER_SET slot_number = (~%resref%~ STR_EQ ~BALDUR25~) ? 3 : 0
+      OUTER_PATCH_SAVE baf ~%baf%~ BEGIN
+        REPLACE_TEXTUALLY ~SaveGame([0-9]+)~ ~SaveGame(%slot_number%)~
+      END
+    END
+    COPY_EXISTING ~%resref%.BCS~ ~override~
+      DECOMPILE_AND_PATCH BEGIN
+        SET len = STRING_LENGTH ~%baf%~
+        INSERT_BYTES 0 len
+        WRITE_ASCIIE 0 ~%baf%~ (len)
+      END
+    BUT_ONLY IF_EXISTS
+  END
+END
+
+
+// Install interval saves according to the given parameters
+DEFINE_ACTION_FUNCTION a7_auto_save
+INT_VAR
+  enabled     = 1     // whether interval save creation is enabled
+  combat      = 0     // whether interval saves can be created during combat
+  interval    = 1800  // time between creating autosave (in seconds)
+  custom_slot = 1     // whether to use a custom save slot
+  count       = 1     // number of saves to cycle through
+  feedback    = 1     // whether to display a feedback message in the combat log
+  use_ini     = 1     // whether to use Baldur.lua configuration options if available
+BEGIN
+  // consistency checks
+  OUTER_SET enabled = enabled ? 1 : 0
+  OUTER_SET combat = combat ? 1 : 0
+  ACTION_IF (NOT FILE_EXISTS_IN_GAME ~savename.2da~) BEGIN
+    OUTER_SET custom_slot = 0
+    ACTION_IF (count > 1) BEGIN OUTER_SET count = 1 END
+  END
+  OUTER_SET count = count < 1 ? 1 : count
+  OUTER_SET count = count > 16 ? 16 : count
+
+  LAF a7_append_savename
+    INT_VAR custom_slot count
+    RET slot
+  END
+
+  LAF a7_append_script
+    INT_VAR enabled combat interval slot count feedback use_ini
+  END
+END

--- a/cdtweaks/readme-cdtweaks.html
+++ b/cdtweaks/readme-cdtweaks.html
@@ -1575,7 +1575,7 @@
       <p><strong>Make party members less likely to die irreversibly</strong><br />
         <em>BGEE,   BG2EE, EET,   BG2, BGT, Tutu</em></p>
       <p>This component tries to prevent &quot;chunking&quot;, the annoying permanent death of your          character when you're reduced below -10 <acronym title="Hit Points">hp</acronym>.          Characters who get reduced to 0 <acronym title="Hit Points">hp</acronym> or          below just die in the usual fashion and can be resurrected. It   isn't possible          to prevent quite all forms of chunking (massive damage from   fire, in particular, still seems to cause chunking fairly reliably), but   this component should make it          a rarer occurrence. This may be useful in the later stages of   the game,          when melee opponents often do 30-40 <acronym title="Hit Points">hp</acronym> damage          per blow - that 10 <acronym title="Hit Points">hp</acronym> safety margin          starts to feel slender. </p>
-      <p><strong>Increased party movement speed outside combat (argent77)</strong><br />
+      <p><strong>Increase party movement speed outside combat (argent77)</strong><br />
         <em>BGEE, BG2EE, IWDEE, EET, BG2 (requires TobEx), BGT (requires TobEx), Tutu (requires TobEx), IWD-in-BG2</em></p>
       <p>This tweak allows your party members to walk around at increased speed as long as no hostile creatures are within their visual range. The protagonist will also receive a special ability that can be used to toggle speed bonus on or off. The following options are available:</p>
       <ul>
@@ -1583,6 +1583,28 @@
         <li>Increase movement speed by 100 percent (same speed as with Boots of Speed)</li>
         <li>Increase movement speed by 150 percent</li>
       </ul>
+      <p><strong>Create interval saves (argent77)</strong><br />
+        <em>BGEE, BG2EE, IWDEE, EET, PSTEE</em></p>
+      <p>This tweak installs a script that automatically saves the game at regular intervals. For games patched to version 2.0 or later the game will be saved to the custom slot "Interval-Save". Games prior to patch 2.0 will use the "Auto-Save" slot instead. The following options are available:</p>
+      <ul>
+        <li>Save every 15 minutes (one save only)</li>
+        <li>Save every 30 minutes (one save only)</li>
+        <li>Save every 60 minutes (one save only)</li>
+        <li>Save every 120 minutes (one save only)</li>
+        <li>Save every 15 minutes (cycle through four saves) <em>-- requires game patch 2.0 or later</em></li>
+        <li>Save every 30 minutes (cycle through four saves) <em>-- requires game patch 2.0 or later</em></li>
+        <li>Save every 60 minutes (cycle through four saves) <em>-- requires game patch 2.0 or later</em></li>
+        <li>Save every 120 minutes (cycle through four saves) <em>-- requires game patch 2.0 or later</em></li>
+        <li>Customize (via cdtweaks.txt)
+          <div>This option looks for values defined in the configuration file "cdtweaks.txt" and uses them accordingly if available. Defaults to values based on "Save every 30 minutes (one save only)", otherwise.</div>
+        </li>
+      </ul>
+      <p>Interval saves can be toggled on and off with the following Baldur.lua option:</p>
+      <div class="code">SetPrivateProfileString('Script','IntervalSaveEnabled','1')</div>
+      <p>Set it to 0 to deactivate creating interval saves. The option is turned on by default. For games prior to patch 2.0 you have to set a game variable with the following console command instead: <em style="white-space:nowrap;">C:SetGlobal("A7-IntervalSaveEnabled","GLOBAL",1)</em></p>
+      <p>It is also possible to allow creating interval saves during combat with the following Baldur.lua option:</p>
+      <div class="code">SetPrivateProfileString('Script','IntervalSaveCombat','0')</div>
+      <p>Set it to 1 to allow creation of interval saves during combat. The option is turned off by default. For games prior to patch 2.0 you have to set a game variable with following console command instead: <em style="white-space:nowrap;">C:SetGlobal("A7-IntervalSaveCombat","GLOBAL",0)</em></p>
     </div>
     <div class="ribbon_rectangle_h3">
       <h3>Joinable NPC Tweaks </h3>

--- a/cdtweaks/setup-cdtweaks.tp2
+++ b/cdtweaks/setup-cdtweaks.tp2
@@ -13126,6 +13126,216 @@ END
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////                                                  \\\\\
+///// Create interval saves                            \\\\\
+/////                                                  \\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+
+/////                                                  \\\\\
+///// Every 15 minutes (one save only)                 \\\\\
+/////                                                  \\\\\
+
+BEGIN @335001 DESIGNATED 3350
+GROUP @4
+REQUIRE_PREDICATE (GAME_IS ~bgee bg2ee eet iwdee pstee~) @25
+SUBCOMPONENT @335000
+
+INCLUDE ~cdtweaks/lib/interval_saves.tpa~
+
+LAF a7_auto_save
+  INT_VAR
+    interval = 900
+    count = 1
+END
+
+/////                                                  \\\\\
+///// Every 30 minutes (one save only)                 \\\\\
+/////                                                  \\\\\
+
+BEGIN @335002 DESIGNATED 3351
+GROUP @4
+REQUIRE_PREDICATE (GAME_IS ~bgee bg2ee eet iwdee pstee~) @25
+SUBCOMPONENT @335000
+
+INCLUDE ~cdtweaks/lib/interval_saves.tpa~
+
+LAF a7_auto_save
+  INT_VAR
+    interval = 1800
+    count = 1
+END
+
+/////                                                  \\\\\
+///// Every 60 minutes (one save only)                 \\\\\
+/////                                                  \\\\\
+
+BEGIN @335003 DESIGNATED 3352
+GROUP @4
+REQUIRE_PREDICATE (GAME_IS ~bgee bg2ee eet iwdee pstee~) @25
+SUBCOMPONENT @335000
+
+INCLUDE ~cdtweaks/lib/interval_saves.tpa~
+
+LAF a7_auto_save
+  INT_VAR
+    interval = 3600
+    count = 1
+END
+
+/////                                                  \\\\\
+///// Every 120 minutes (one save only)                \\\\\
+/////                                                  \\\\\
+
+BEGIN @335004 DESIGNATED 3353
+GROUP @4
+REQUIRE_PREDICATE (GAME_IS ~bgee bg2ee eet iwdee pstee~) @25
+SUBCOMPONENT @335000
+
+INCLUDE ~cdtweaks/lib/interval_saves.tpa~
+
+LAF a7_auto_save
+  INT_VAR
+    interval = 7200
+    count = 1
+END
+
+/////                                                  \\\\\
+///// Every 15 minutes (cycle through four saves)      \\\\\
+/////                                                  \\\\\
+
+BEGIN @335005 DESIGNATED 3354
+GROUP @4
+REQUIRE_PREDICATE (GAME_IS ~bgee bg2ee eet iwdee pstee~ && FILE_EXISTS_IN_GAME ~savename.2da~) @25
+SUBCOMPONENT @335000
+
+INCLUDE ~cdtweaks/lib/interval_saves.tpa~
+
+LAF a7_auto_save
+  INT_VAR
+    interval = 900
+    count = 4
+END
+
+/////                                                  \\\\\
+///// Every 30 minutes (cycle through four saves)      \\\\\
+/////                                                  \\\\\
+
+BEGIN @335006 DESIGNATED 3355
+GROUP @4
+REQUIRE_PREDICATE (GAME_IS ~bgee bg2ee eet iwdee pstee~ && FILE_EXISTS_IN_GAME ~savename.2da~) @25
+SUBCOMPONENT @335000
+
+INCLUDE ~cdtweaks/lib/interval_saves.tpa~
+
+LAF a7_auto_save
+  INT_VAR
+    interval = 1800
+    count = 4
+END
+
+/////                                                  \\\\\
+///// Every 60 minutes (cycle through four saves)      \\\\\
+/////                                                  \\\\\
+
+BEGIN @335007 DESIGNATED 3356
+GROUP @4
+REQUIRE_PREDICATE (GAME_IS ~bgee bg2ee eet iwdee pstee~ && FILE_EXISTS_IN_GAME ~savename.2da~) @25
+SUBCOMPONENT @335000
+
+INCLUDE ~cdtweaks/lib/interval_saves.tpa~
+
+LAF a7_auto_save
+  INT_VAR
+    interval = 3600
+    count = 4
+END
+
+/////                                                  \\\\\
+///// Every 120 minutes (cycle through four saves)     \\\\\
+/////                                                  \\\\\
+
+BEGIN @335008 DESIGNATED 3357
+GROUP @4
+REQUIRE_PREDICATE (GAME_IS ~bgee bg2ee eet iwdee pstee~ && FILE_EXISTS_IN_GAME ~savename.2da~) @25
+SUBCOMPONENT @335000
+
+INCLUDE ~cdtweaks/lib/interval_saves.tpa~
+
+LAF a7_auto_save
+  INT_VAR
+    interval = 7200
+    count = 4
+END
+
+/////                                                  \\\\\
+///// Customize                                        \\\\\
+/////                                                  \\\\\
+
+BEGIN @335009 DESIGNATED 3358
+GROUP @4
+REQUIRE_PREDICATE (GAME_IS ~bgee bg2ee eet iwdee pstee~ && FILE_EXISTS_IN_GAME ~savename.2da~) @25
+SUBCOMPONENT @335000
+
+INCLUDE ~cdtweaks/lib/interval_saves.tpa~
+
+ACTION_IF (FILE_EXISTS ~cdtweaks/cdtweaks.txt~) THEN BEGIN
+  INCLUDE ~cdtweaks/cdtweaks.txt~ // config file
+END
+ACTION_IF (NOT IS_AN_INT ~interval_save_enabled~) BEGIN OUTER_SET interval_save_enabled = 1 END
+ACTION_IF (NOT IS_AN_INT ~interval_save_delay~) BEGIN OUTER_SET interval_save_delay = 1800 END
+ACTION_IF (NOT IS_AN_INT ~interval_save_combat~) BEGIN OUTER_SET interval_save_combat = 0 END
+ACTION_IF (NOT IS_AN_INT ~interval_save_count~) BEGIN OUTER_SET interval_save_count = 1 END
+ACTION_IF (NOT IS_AN_INT ~interval_save_custom_slot~) BEGIN OUTER_SET interval_save_custom_slot = 1 END
+ACTION_IF (NOT IS_AN_INT ~interval_save_feedback~) BEGIN OUTER_SET interval_save_feedback = 1 END
+ACTION_IF (NOT IS_AN_INT ~interval_save_ini~) BEGIN OUTER_SET interval_save_ini = 1 END
+
+// Show configuration info
+OUTER_SPRINT msg @335103
+OUTER_PATCH_SAVE msg ~%msg%~ BEGIN
+  PATCH_IF (interval_save_enabled) BEGIN
+    REPLACE_TEXTUALLY ~a7_interval_enable~ ~yes~
+  END ELSE BEGIN
+    REPLACE_TEXTUALLY ~a7_interval_enable~ ~no~
+  END
+  REPLACE_TEXTUALLY ~a7_interval_delay~ ~%interval_save_delay%~
+  PATCH_IF (interval_save_combat) BEGIN
+    REPLACE_TEXTUALLY ~a7_interval_combat~ ~yes~
+  END ELSE BEGIN
+    REPLACE_TEXTUALLY ~a7_interval_combat~ ~no~
+  END
+  REPLACE_TEXTUALLY ~a7_interval_slots~ ~%interval_save_count%~
+  PATCH_IF (interval_save_custom_slot) BEGIN
+    REPLACE_TEXTUALLY ~a7_interval_custom~ ~yes~
+  END ELSE BEGIN
+    REPLACE_TEXTUALLY ~a7_interval_custom~ ~no~
+  END
+  PATCH_IF (interval_save_feedback) BEGIN
+    REPLACE_TEXTUALLY ~a7_interval_feedback~ ~yes~
+  END ELSE BEGIN
+    REPLACE_TEXTUALLY ~a7_interval_feedback~ ~no~
+  END
+  PATCH_IF (interval_save_ini) BEGIN
+    REPLACE_TEXTUALLY ~a7_interval_ini~ ~yes~
+  END ELSE BEGIN
+    REPLACE_TEXTUALLY ~a7_interval_ini~ ~no~
+  END
+END
+PRINT ~%msg%~
+
+LAF a7_auto_save
+  INT_VAR
+    enabled     = interval_save_enabled
+    combat      = interval_save_combat
+    interval    = interval_save_delay
+    custom_slot = interval_save_custom_slot
+    count       = interval_save_count
+    feedback    = interval_save_feedback
+    use_ini     = interval_save_ini
+END
+
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////                                                  \\\\\
 ///// Adjust Evil joinable NPC reaction rolls          \\\\\
 /////                                                  \\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\


### PR DESCRIPTION
This tweak will create automatic saves at regular intervals, which can be helpful if the game crashes or the player decides to revert to an earlier stage of the game.

The component supports all EE games - with enhanced functionality for games patched to 2.0 or later (such as multiple save slots, custom save name, options set via Baldur.lua, etc.).