### PR TITLE
Auto-Haste: Fix duplicate script blocks in baldur.bcs (EET)

### DIFF
--- a/cdtweaks/lib/increased_party_movement_speed.tpa
+++ b/cdtweaks/lib/increased_party_movement_speed.tpa
@@ -196,39 +196,33 @@ END
 // Adds a script on top or at the bottom of all available global scripts (i.e. baldur.bcs, etc.)
 DEFINE_ACTION_FUNCTION A7_ADD_GLOBAL_SCRIPT
 INT_VAR
-  extend_top = 1  // 0: EXTEND_BOTTOM, 1: EXTEND_TOP
+  extend_top = 1    // 0: EXTEND_BOTTOM, 1: EXTEND_TOP
 STR_VAR
   script_file = ~~  // filename of the script to add (leave empty to skip)
   script = ~~       // Script content to add (leave empty to skip)
 BEGIN
-  OUTER_SET baldur = 0
-  OUTER_SET baldur25 = 0
+  ACTION_CLEAR_ARRAY ~script_files~
+
+  // hardcoded script files
+  OUTER_SET $script_files(~BALDUR~) = 1
+  OUTER_SET $script_files(~BALDUR25~) = 1
+
+  // externalized script files
   COPY_EXISTING ~campaign.2da~ ~override~
     COUNT_2DA_ROWS 32 numRows
     FOR (row = 0; row < numRows; ++row) BEGIN
       READ_2DA_ENTRY row 1 32 resref
-      PATCH_IF (FILE_EXISTS_IN_GAME ~%resref%.bcs~) BEGIN
-        PATCH_MATCH ~%resref%~ WITH
-          ~BALDUR~ BEGIN SET baldur = 1 END
-          ~BALDUR25~ BEGIN SET baldur25 = 1 END
-          DEFAULT
-        END
-        INNER_ACTION BEGIN
-          OUTER_TEXT_SPRINT source_file ~%resref%.bcs~
-          LAM __A7_EXTEND_SCRIPT
-        END
-      END
+      TO_UPPER ~resref~
+      SET $script_files(~%resref%~) = 1
     END
   BUT_ONLY IF_EXISTS
 
-  ACTION_IF (baldur = 0) BEGIN
-    OUTER_TEXT_SPRINT source_file ~baldur.bcs~
-    LAM __A7_EXTEND_SCRIPT
-  END
-
-  ACTION_IF (baldur25 = 0) BEGIN
-    OUTER_TEXT_SPRINT source_file ~baldur25.bcs~
-    LAM __A7_EXTEND_SCRIPT
+  // append script to files
+  ACTION_PHP_EACH script_files AS resref => value BEGIN
+    ACTION_IF (IS_AN_INT ~value~ && value != 0) BEGIN
+      OUTER_TEXT_SPRINT source_file ~%resref%.bcs~
+      LAM __A7_EXTEND_SCRIPT
+    END
   END
 END
 


### PR DESCRIPTION
Component "Increased party movement outside combat": This fix removes duplicate script blocks from baldur.bcs in EET which resulted in multiple instances of the auto-haste innate ability for the protagonist.