### PR TITLE
Update unique_containers_fixes.tpa

### DIFF
--- a/cdtweaks/lib/unique_containers_fixes.tpa
+++ b/cdtweaks/lib/unique_containers_fixes.tpa
@@ -239,7 +239,9 @@ ACTION_IF FILE_EXISTS_IN_GAME ~bhperk.sto~ BEGIN //Bone Hill
       REMOVE_STORE_ITEM ~bag06~ ~bag03g~ ~bag02~ //Already in other stores
     END
   BUT_ONLY
+END  
 
+ACTION_IF FILE_EXISTS_IN_GAME ~bhxspell.sto~ BEGIN
   COPY_EXISTING ~bhxspell.sto~ ~override~ //X Scrolls
     PATCH_IF SOURCE_SIZE > 0x9b BEGIN
 


### PR DESCRIPTION
The bhxspell.sto does not exist anymore in the updated Bone Hill Mod for EE.
The itm and relate sto were never used by the mod anyway and the scrolls that the fix tries to remove never existed. The whole package was some unfinished idea in the mod.
The non-EE mod is not maintained, thus making the fix conditional should be sufficient.