### PR TITLE
Fix for IWDEE Chill Touch

### DIFF
--- a/cdtweaks/languages/english/setup.tra
+++ b/cdtweaks/languages/english/setup.tra
@@ -321,6 +321,7 @@
  @20100 = ~Remove Blur and Reflection Effects from Items (Daeros Trollkiller)~
  
  @21000 = ~Separate Resist Fire/Cold Icon into Separate Icons (Angel)~
+ @21001 = ~Fix Chill Touch (Luke)~
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////                                                  \\\\\

--- a/cdtweaks/lib/chill_touch_fix.tph
+++ b/cdtweaks/lib/chill_touch_fix.tph
@@ -1,0 +1,84 @@
+DEFINE_ACTION_FUNCTION "CHILL_TOUCH_FIX"
+BEGIN
+	LAF "RES_NUM_OF_SPELL_NAME"
+	STR_VAR
+		"spell_name" = "WIZARD_CHILL_TOUCH"
+	RET
+		"spell_res"
+	END
+
+	////////////////////////////////////////////////////////////////////
+	//// Magically created weapon
+	////////////////////////////////////////////////////////////////////
+
+	WITH_SCOPE BEGIN
+		COPY_EXISTING "CTOUCH.ITM" "override"
+			// op337 always acts as permanent
+			LPF "DELETE_EFFECT"
+			INT_VAR
+				"check_globals" = 0
+				"match_opcode" = 326 // Apply effects list
+			STR_VAR
+				"match_resource" = EVALUATE_BUFFER "%spell_res%C"
+			END
+			LPF "ALTER_EFFECT"
+			INT_VAR
+				"check_globals" = 0
+				"match_opcode" = 326 // Apply effects list
+				"timing" = 1 // Permanent until death
+				"duration" = 0
+				"resist_dispel" = 2 // Remember that the Magic Resistance field is checked BEFORE the splprot/IDS filter, so it's usually better to not have Magic Resistance on op326, to avoid unnecessary feedback.
+				"savingthrow" = 0 // Remember that the Saving Throw field is checked BEFORE the splprot/IDS filter, so it's usually better to not have Saving Throws on op326, to avoid unnecessary feedback.
+			STR_VAR
+				"match_resource" = EVALUATE_BUFFER "%spell_res%A"
+			END
+			LPF "ALTER_EFFECT"
+			INT_VAR
+				"check_globals" = 0
+				"match_opcode" = 326 // Apply effects list
+				"timing" = 1 // Permanent until death
+				"duration" = 0
+				"resist_dispel" = 2 // Remember that the Magic Resistance field is checked BEFORE the splprot/IDS filter, so it's usually better to not have Magic Resistance on op326, to avoid unnecessary feedback.
+				"savingthrow" = 0 // Remember that the Saving Throw field is checked BEFORE the splprot/IDS filter, so it's usually better to not have Saving Throws on op326, to avoid unnecessary feedback.
+			STR_VAR
+				"match_resource" = EVALUATE_BUFFER "%spell_res%B"
+			END
+		BUT_ONLY_IF_IT_CHANGES
+	END
+
+	////////////////////////////////////////////////////////////////////
+	//// Subspell affecting GENERAL = UNDEAD
+	////////////////////////////////////////////////////////////////////
+
+	WITH_SCOPE BEGIN
+		COPY_EXISTING "%spell_res%a.spl" "override"
+			LPF "ALTER_EFFECT"
+			INT_VAR
+				"check_globals" = 0
+				"resist_dispel" = 1 // Dispel/Not bypass MR
+				"savingthrow" = BIT0 // Save vs. Spell
+			END
+			LPF "ALTER_EFFECT"
+			INT_VAR
+				"check_globals" = 0
+				"match_opcode" = 24 // Panic
+				"parameter2" = 1 // Panic type => Bypass op101
+			END
+		BUT_ONLY_IF_IT_CHANGES
+	END
+
+	////////////////////////////////////////////////////////////////////
+	//// Subspell affecting GENERAL != UNDEAD
+	////////////////////////////////////////////////////////////////////
+
+	WITH_SCOPE BEGIN
+		COPY_EXISTING "%spell_res%b.spl" "override"
+			LPF "ALTER_EFFECT"
+			INT_VAR
+				"check_globals" = 0
+				"resist_dispel" = 1 // Dispel/Not bypass MR
+				"savingthrow" = BIT0 // Save vs. Spell
+			END
+		BUT_ONLY_IF_IT_CHANGES
+	END
+END

--- a/cdtweaks/setup-cdtweaks.tp2
+++ b/cdtweaks/setup-cdtweaks.tp2
@@ -80,7 +80,7 @@ LANGUAGE
   ~cdtweaks/languages/english/description_updates.tra~
   ~cdtweaks/languages/english/setup.tra~
 LANGUAGE
-  ~Czech (Translation by Razfallow and Vlasák)~
+  ~Czech (Translation by Razfallow and Vlasï¿½k)~
   ~czech~
   ~cdtweaks/languages/english/setup.tra~
   ~cdtweaks/languages/czech/setup.tra~
@@ -1131,7 +1131,22 @@ COPY_EXISTING_REGEXP GLOB ~^.+\.cre$~ ~override~
   LPF cd_apply_batch STR_VAR array_name = cd_fire_icons END
   BUT_ONLY
 
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////                                                            \\\\\
+///// Fix IWDEE Chill Touch                                      \\\\\
+/////                                                            \\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 
+BEGIN @21001 DESIGNATED 202
+GROUP @11
+REQUIRE_PREDICATE GAME_IS ~iwdee~ @25
+
+WITH_SCOPE BEGIN
+  INCLUDE ~cdtweaks/lib/chill_touch_fix.tph~
+  LAF "CHILL_TOUCH_FIX" END
+END
 
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\


### PR DESCRIPTION
Since this mod is supposed to be a big collection of tweaks/fixes, I'll leave this here.

This spell is currently broken due to how `opcode #337` works (it always acts as permanent). As a result, I removed it and set `parameter2` of `opcode #24` to `1` in order to bypass the immunity to Panic granted by `opcode #101`.

Additionally, I also made sure the spell does not offer unnecessary/duplicate combat feedback (MR and Saving Throw checks have been moved from `opcode #326` to subspells).