### PR TITLE
Add missing Polish translation for "Small Sword" proficiency

### DIFF
--- a/cdtweaks/languages/polish/game.tra
+++ b/cdtweaks/languages/polish/game.tra
@@ -318,6 +318,7 @@ Ostrze¿enie: Magiczne katany s¹ bardzo rzadkie w Baldur`s Gate 2!
 <DOTS5>~
 @216007 = ~Rodzaj\( bieg³oœci\)?[:-] *~
 @216008 = ~Rodzaj bieg³oœci:~
+@216101 = ~Lekki miecz~
 @218001 = ~Alchemia (Mag)~
 @218002 = ~Alchemia (Kap³an)~
 @218003 = ~Alchemia (£otrzyk)~


### PR DESCRIPTION
Found missing line in Polish translation for component "Alter Weapon Proficiency System".