### PR TITLE
Backstab immunity

### DIFF
--- a/cdtweaks/languages/english/weidu.tra
+++ b/cdtweaks/languages/english/weidu.tra
@@ -422,6 +422,8 @@
 
 @259000 = ~Thieves Can Backstab With More Weapons With "Use Any Item" or as Dual- and Multi-Classes~
 
+@262000 = "Make certain creatures immune to backstab / sneak attack"
+
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////                                                  \\\\\

--- a/cdtweaks/lib/backstab_immunity.tph
+++ b/cdtweaks/lib/backstab_immunity.tph
@@ -1,0 +1,115 @@
+DEFINE_ACTION_FUNCTION "BACKSTAB_IMMUNITY"
+BEGIN
+	WITH_SCOPE BEGIN
+		COPY_EXISTING_REGEXP "^.+\.cre$" "override"
+			SET "found" = 0
+			PATCH_MATCH BYTE_AT 0x271 WITH // GENERAL check
+				IDS_OF_SYMBOL ("GENERAL" "UNDEAD")
+				IDS_OF_SYMBOL ("GENERAL" "PLANT")
+				IDS_OF_SYMBOL ("GENERAL" "WEAPON")
+				BEGIN
+					SET "found" = 1
+					LPF "BACKSTAB_IMMUNITY_HELPER" END
+				END
+				DEFAULT
+			END
+			PATCH_IF !("%found%") BEGIN
+				PATCH_MATCH BYTE_AT 0x272 WITH // RACE check
+					IDS_OF_SYMBOL ("RACE" "SLIME")
+					IDS_OF_SYMBOL ("RACE" "BEHOLDER")
+					IDS_OF_SYMBOL ("RACE" "DEMONIC")
+					IDS_OF_SYMBOL ("RACE" "MEPHIT")
+					IDS_OF_SYMBOL ("RACE" "IMP")
+					IDS_OF_SYMBOL ("RACE" "DRAGON")
+					IDS_OF_SYMBOL ("RACE" "ELEMENTAL")
+					IDS_OF_SYMBOL ("RACE" "SALAMANDER")
+					IDS_OF_SYMBOL ("RACE" "MIST")
+					IDS_OF_SYMBOL ("RACE" "SOLAR")
+					IDS_OF_SYMBOL ("RACE" "ANTISOLAR")
+					IDS_OF_SYMBOL ("RACE" "PLANATAR")
+					IDS_OF_SYMBOL ("RACE" "DARKPLANATAR")
+					BEGIN
+						LPF "BACKSTAB_IMMUNITY_HELPER" END
+					END
+					IDS_OF_SYMBOL ("RACE" "GOLEM")
+					BEGIN
+						PATCH_MATCH BYTE_AT 0x273 WITH
+							IDS_OF_SYMBOL ("CLASS" "GOLEM_CLAY")
+							IDS_OF_SYMBOL ("CLASS" "GOLEM_STONE")
+							IDS_OF_SYMBOL ("CLASS" "GOLEM_IRON")
+							BEGIN
+								LPF "BACKSTAB_IMMUNITY_HELPER" END
+							END
+							DEFAULT
+						END
+					END
+					DEFAULT
+				END
+			END
+		BUT_ONLY_IF_IT_CHANGES
+	END
+END
+
+/////////////////////////////////////////////////////////////////
+/*
+
+Auxiliary function
+
+*/
+//////////////////////////////////////////////////////////////////
+
+DEFINE_PATCH_FUNCTION "BACKSTAB_IMMUNITY_HELPER"
+BEGIN
+	// Initialize
+	SET "found" = 0
+	// Check if the immunity is already granted by its equipment
+	GET_OFFSET_ARRAY "cre_v10_items" CRE_V10_ITEMS
+	PHP_EACH "cre_v10_items" AS "itm_ind" => "itm_off" BEGIN
+		PATCH_MATCH "%itm_ind%" WITH
+			SSHORT_AT (LONG_AT 0x2B8 + 0x0) // Helmet
+			SSHORT_AT (LONG_AT 0x2B8 + 0x2) // Armor
+			SSHORT_AT (LONG_AT 0x2B8 + 0x4) // Shield
+			SSHORT_AT (LONG_AT 0x2B8 + 0x6) // Gloves
+			SSHORT_AT (LONG_AT 0x2B8 + 0x8) // Left ring
+			SSHORT_AT (LONG_AT 0x2B8 + 0xA) // Right ring
+			SSHORT_AT (LONG_AT 0x2B8 + 0xC) // Amulet
+			SSHORT_AT (LONG_AT 0x2B8 + 0xE) // Belt
+			SSHORT_AT (LONG_AT 0x2B8 + 0x10) // Boots
+			SSHORT_AT (LONG_AT 0x2B8 + 0x12) // Weapon 1
+			SSHORT_AT (LONG_AT 0x2B8 + 0x14) // Weapon 2
+			SSHORT_AT (LONG_AT 0x2B8 + 0x16) // Weapon 3
+			SSHORT_AT (LONG_AT 0x2B8 + 0x18) // Weapon 4
+			SSHORT_AT (LONG_AT 0x2B8 + 0x22) // Cloak
+			BEGIN
+				READ_ASCII "%itm_off%" "itm_resref"
+				INNER_PATCH_FILE "%itm_resref%.itm" BEGIN
+					GET_OFFSET_ARRAY "fx_array" ITM_V10_GEN_EFFECTS
+					PHP_EACH "fx_array" AS "fx_ind" => "fx_off" BEGIN
+						PATCH_IF (SHORT_AT "%fx_off%" == 292) BEGIN
+							PATCH_IF (SLONG_AT ("%fx_off%" + 0x8) > 0) BEGIN
+								SET "found" = 1
+							END
+						END
+					END
+				END
+			END
+			DEFAULT
+		END
+	END
+	// Check if the immunity is already present amongst its effects
+	PATCH_IF !("%found%") BEGIN
+		LPF "FJ_CRE_VALIDITY" END // force the CRE file to use EFF V2 effects internally
+		GET_OFFSET_ARRAY "fx_array" CRE_V10_EFFECTS
+		PHP_EACH "fx_array" AS "fx_ind" => "fx_off" BEGIN
+			// NB.: Unlike ordinary V2 EFF files, CRE effect V2 structures omit the 8-byte EFF V2 header!!!
+			PATCH_IF (LONG_AT ("%fx_off%" + (0x10 - 0x8)) == 292) BEGIN
+				PATCH_IF (SLONG_AT ("%fx_off%" + (0x20 - 0x8)) > 0) BEGIN
+					SET "found" = 1
+				END
+			END
+		END
+	END
+	PATCH_IF !("%found%") BEGIN
+		LPF "ADD_CRE_EFFECT" INT_VAR "opcode" = 292 "target" = 1 "parameter2" = 1 "timing" = 9 END
+	END
+END

--- a/cdtweaks/readme-cdtweaks.html
+++ b/cdtweaks/readme-cdtweaks.html
@@ -881,6 +881,58 @@
       <p> <strong>Restore IWD Tooltips</strong><br />
         <em>IWDEE</em></p>
       <p>This component  replaces the existing, explicit IWDEE creature tooltips (typically  the proper name of an NPC) with the more ambiguous tooltips that were  used in the original (typically a physical description). For example,  Arundel used the tooltip "Old Man" in the original IWD instead of  the explicit "Arundel" that he uses in IWDEE. Some other examples  are <a href="https://www.gibberlings3.net/gallery/image/821-restore-iwd-tooltips/">available in the Tweaks gallery</a>. </p>
+      <p> <strong>Make certain creatures immune to backstab / sneak attack</strong><br />
+        <em><abbr title="Baldur's Gate: Enhanced Edition">BGEE</abbr>, <abbr title="Baldur's Gate II: Enhanced Edition">BG2EE</abbr>, <abbr title="Icewind Dale: Enhanced Edition">IWDEE</abbr>, <abbr title="Enhanced Edition Trilogy">EET</abbr></em></p>
+      <p>
+        Technically speaking, a rogue can backstab / sneak attack only <u>living creatures with discernible anatomies</u>.<br />
+        As a result, this component makes sure all those creatures that lack vital areas to attack are immune to backstabs / sneak attacks. This includes the following creatures:
+        <ul>
+          <li><i>Undead</i></li>
+          <li><i>Plants</i></li>
+          <li><i>Oozes</i></li>
+          <li><i>Constructs</i>
+            <ul>
+              <li>all but Flesh Golems</li>
+            </ul>
+          </li>
+          <li><i>Incorporeal creatures that are not undead</i>
+            <ul>
+              <li>Nishruu, Hakeashar, Mist Horror, Poison Mist, etc&hellip;</li>
+            </ul>
+          </li>
+          <li><i>Demonic creatures</i></li>
+          <li>
+            <i>Elementals</i>
+            <ul>
+              <li>this also includes Salamanders</li>
+            </ul>
+          </li>
+          <li>
+            <i>Beholders</i>
+            <ul>
+              <li>due to their 360 degree vision</li>
+            </ul>
+          </li>
+          <li>
+            <i>Celestials</i>
+            <ul>
+              <li>devas, planetars, solars, etc&hellip;</li>
+            </ul>
+          </li>
+          <li>
+            <i>Dragons</i>
+            <ul>
+              <li>due to their enhanced senses</li>
+            </ul>
+          </li>
+          <li>
+            <i>Animated weapons</i>
+            <ul>
+              <li>Mordenkainen's Sword</li>
+            </ul>
+          </li>
+        </ul>
+      </p>
     </div>
     <div class="ribbon_rectangle_h3">
       <h3> <a id="contents_convenience" name="contents_convenience"></a>Convenience Tweaks and/or Cheats </h3>

--- a/cdtweaks/setup-cdtweaks.tp2
+++ b/cdtweaks/setup-cdtweaks.tp2
@@ -9524,6 +9524,24 @@ ACTION_IF game_is_bg2ee OR game_is_eet BEGIN // to try and prevent staff of the 
     
 END
 
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////                                                            \\\\\
+///// Make certain creatures immune to backstab / sneak attack   \\\\\
+/////                                                            \\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+
+BEGIN @262000 DESIGNATED 2620
+GROUP @9
+REQUIRE_PREDICATE GAME_IS ~bgee bg2ee eet iwdee~ @25
+LABEL ~cd_tweaks_backstab_immunity~
+
+WITH_SCOPE BEGIN
+  INCLUDE "cdtweaks/lib/backstab_immunity.tph"
+  LAF "BACKSTAB_IMMUNITY" END
+END
+
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////                                                  \\\\\


### PR DESCRIPTION
This pull request tries to implement the following idea:
### UNDEAD, GOLEM (Clay/Iron/Stone, not Flesh), SLIME, DRAGON, DEMONIC and so forth should be immune to backstab/sneak attack (`opcode #292`)...

In particular, it will make sure the following creatures are immune to backstab / sneak attack:
<ul>
          <li><i>Undead</i></li>
          <li><i>Plants</i></li>
          <li><i>Oozes</i></li>
          <li><i>Constructs</i>
            <ul>
              <li>all but Flesh Golems</li>
            </ul>
          </li>
          <li><i>Incorporeal creatures that are not undead</i>
            <ul>
              <li>Nishruu, Hakeashar, Mist Horror, Poison Mist, etc&hellip;</li>
            </ul>
          </li>
          <li><i>Demonic creatures</i></li>
          <li>
            <i>Elementals</i>
            <ul>
              <li>this also includes Salamanders</li>
            </ul>
          </li>
          <li>
            <i>Beholders</i>
            <ul>
              <li>due to their 360 degree vision</li>
            </ul>
          </li>
          <li>
            <i>Celestials</i>
            <ul>
              <li>devas, planetars, solars, etc&hellip;</li>
            </ul>
          </li>
          <li>
            <i>Dragons</i>
            <ul>
              <li>due to their enhanced senses</li>
            </ul>
          </li>
          <li>
            <i>Animated weapons</i>
            <ul>
              <li>Mordenkainen's Sword</li>
            </ul>
          </li>