### PR TITLE
fixed auto-haste sometimes not disabling during combat

### DIFF
--- a/cdtweaks/baf/a7#haste_sectype.baf
+++ b/cdtweaks/baf/a7#haste_sectype.baf
@@ -2,6 +2,7 @@
 
 IF
   Global("A7_AutoHasteActive","GLOBAL",1)
+  !GlobalTimerNotExpired("A7_AutoHasteTimerPartyCombatCD","GLOBAL")
   OR(2)
     !GlobalTimerNotExpired("A7_AutoHasteTimer%suffix%","GLOBAL")
     TriggerOverride(%player%,Global("A7_AutoHasteActive","LOCALS",0))
@@ -23,6 +24,7 @@ IF
 THEN
   RESPONSE #100
     ApplySpellRES("a7_wlk2",%player%)
+    SetGlobalTimer("A7_AutoHasteTimerPartyCombatCD","GLOBAL",12)
     Continue()
 END
 
@@ -32,5 +34,6 @@ IF
 THEN
   RESPONSE #100
     ApplySpellRES("a7_wlk2",%player%)
+    SetGlobal("A7_AutoHasteActive","GLOBAL",2)
     Continue()
 END

--- a/cdtweaks/baf/a7#haste_sectype_special.baf
+++ b/cdtweaks/baf/a7#haste_sectype_special.baf
@@ -2,6 +2,7 @@
 
 IF
   Global("A7_AutoHasteActive","GLOBAL",1)
+  !GlobalTimerNotExpired("A7_AutoHasteTimerPartyCombatCD","GLOBAL")
   Allegiance("%name%",FAMILIAR)
   InMyArea("%name%")
   OR(2)
@@ -25,6 +26,7 @@ IF
 THEN
   RESPONSE #100
     ApplySpellRES("a7_wlk2","%name%")
+    SetGlobalTimer("A7_AutoHasteTimerPartyCombatCD","GLOBAL",12)
     Continue()
 END
 
@@ -34,5 +36,6 @@ IF
 THEN
   RESPONSE #100
     ApplySpellRES("a7_wlk2","%name%")
+    SetGlobal("A7_AutoHasteActive","GLOBAL",2)
     Continue()
 END

--- a/cdtweaks/baf/a7#haste_splstate.baf
+++ b/cdtweaks/baf/a7#haste_splstate.baf
@@ -2,6 +2,7 @@
 
 IF
   Global("A7_AutoHasteActive","GLOBAL",1)
+  !GlobalTimerNotExpired("A7_AutoHasteTimerPartyCombatCD","GLOBAL")
   OR(2)
     !GlobalTimerNotExpired("A7_AutoHasteTimer%suffix%","GLOBAL")
     !CheckSpellState(%player%,A7_AUTO_SPEED)
@@ -23,6 +24,7 @@ IF
 THEN
   RESPONSE #100
     ApplySpellRES("a7_wlk2",%player%)
+    SetGlobalTimer("A7_AutoHasteTimerPartyCombatCD","GLOBAL",12)
     Continue()
 END
 
@@ -32,5 +34,6 @@ IF
 THEN
   RESPONSE #100
     ApplySpellRES("a7_wlk2",%player%)
+    SetGlobal("A7_AutoHasteActive","GLOBAL",2)
     Continue()
 END

--- a/cdtweaks/baf/a7#haste_splstate_special.baf
+++ b/cdtweaks/baf/a7#haste_splstate_special.baf
@@ -2,6 +2,7 @@
 
 IF
   Global("A7_AutoHasteActive","GLOBAL",1)
+  !GlobalTimerNotExpired("A7_AutoHasteTimerPartyCombatCD","GLOBAL")
   !Name("%name%",Familiar)
   Allegiance("%name%",FAMILIAR)
   InMyArea("%name%")
@@ -26,6 +27,7 @@ IF
 THEN
   RESPONSE #100
     ApplySpellRES("a7_wlk2","%name%")
+    SetGlobalTimer("A7_AutoHasteTimerPartyCombatCD","GLOBAL",12)
     Continue()
 END
 
@@ -35,5 +37,6 @@ IF
 THEN
   RESPONSE #100
     ApplySpellRES("a7_wlk2","%name%")
+    SetGlobal("A7_AutoHasteActive","GLOBAL",2)
     Continue()
 END


### PR DESCRIPTION
... by adding a party-shared cooldown upon any party member seeing an enemy.
This solved rare cases when some party members get hasted when their LOS to enemy are broken by pillars, desks, etc.