### PR TITLE
Typo in "Personalize automatic save names"

### DIFF
--- a/cdtweaks/lib/personalized_save_names.tpa
+++ b/cdtweaks/lib/personalized_save_names.tpa
@@ -9,7 +9,7 @@ STR_VAR
   charname_string = ~~  // e.g. "(<CHARNAME>)-"
 RET new_string
 BEGIN
-  TEXT_SPRINT new_strig ~~
+  TEXT_SPRINT new_string ~~
 
   PATCH_IF (~%old_string%~ STRING_MATCHES_REGEXP ~[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-.+~ = 0) BEGIN
     INNER_PATCH_SAVE new_string ~%old_string%~ BEGIN


### PR DESCRIPTION
Fixed a typo in the return variable name of a WeiDU function which might trigger an "uninitialized return value" WeiDU error under certain conditions.