### PR TITLE
Spontaneous Casting for Clerics

### DIFF
--- a/cdtweaks/languages/english/spontaneous_casting.tra
+++ b/cdtweaks/languages/english/spontaneous_casting.tra
@@ -1,0 +1,3 @@
+@0 = "It can only be cast by good-aligned characters"
+@1 = "It can only be cast by evil-aligned characters"
+@2 = "The character must have at least one level %spellLevel% spell memorized to spontaneously cast this spell"

--- a/cdtweaks/languages/english/weidu.tra
+++ b/cdtweaks/languages/english/weidu.tra
@@ -35,6 +35,8 @@
 @26 = ~Using values from the cdtweaks.txt config file for this component...~
 @27 = ~DLC Merger is required before mods can be installed on this game. Check the readme for more information and a link to download DLC Merger.~
 @28 = ~There are not enough free spell state or secondary type slots available to install this component.~
+@29 = "Requires EEex (https://github.com/Bubb13/EEex)."
+@30 = "One or more Cure/Cause Wounds spells are missing. Make sure either the Divine Spell Pack from IWDification is installed (https://github.com/Gibberlings3/iwdification) or you are modding IWD:EE."
 
 @100 = ~Batch Installer -- EXPERIMENTAL, use at own risk. Check the readme.~
 @101 = ~
@@ -432,6 +434,8 @@ The uninstall messages above are normal and expected.
 @263000 = "Improved Cure / Cause Wounds [Luke]"
 
 @264000 = "PnP Potions [Luke]"
+
+@265000 = "Spontaneous Casting for Clerics [Luke]"
 
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\

--- a/cdtweaks/languages/italian/spontaneous_casting.tra
+++ b/cdtweaks/languages/italian/spontaneous_casting.tra
@@ -1,0 +1,3 @@
+@0 = "Può essere lanciato solo da personaggi di allineamento buono"
+@1 = "Può essere lanciato solo da personaggi di allineamento malvagio"
+@2 = "Il personaggio deve avere almeno un incantesimo di livello %spellLevel% memorizzato per poter lanciare spontaneamente questo incantesimo"

--- a/cdtweaks/lib/comp_2650.tph
+++ b/cdtweaks/lib/comp_2650.tph
@@ -1,0 +1,15 @@
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////                                                            \\\\\
+///// Spontaneous Casting for Clerics                            \\\\\
+/////                                                            \\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+
+WITH_SCOPE BEGIN
+  INCLUDE "cdtweaks\luke\misc.tph"
+  INCLUDE "cdtweaks\lib\spontaneous_casting.tph"
+  WITH_TRA "cdtweaks\languages\english\spontaneous_casting.tra" "cdtweaks\languages\%LANGUAGE%\spontaneous_casting.tra" BEGIN
+    LAF "SPONTANEOUS_CASTING" END
+  END
+END

--- a/cdtweaks/lib/spontaneous_casting.tph
+++ b/cdtweaks/lib/spontaneous_casting.tph
@@ -1,0 +1,146 @@
+DEFINE_ACTION_FUNCTION "SPONTANEOUS_CASTING"
+BEGIN
+	LAM "READ_SPELL_IDS"
+	LAF "SPONTANEOUS_CASTING#GET_CLERIC_CLAB_FILES" RET_ARRAY "cleric_clab_files" END
+	//
+	<<<<<<<< .../cdtweaks-inlined/empty
+	>>>>>>>>
+	//
+	WITH_SCOPE BEGIN
+		ACTION_IF !(FILE_EXISTS_IN_GAME "m_gt#402.lua") BEGIN
+			COPY ".../cdtweaks-inlined/empty" "override\m_gt#402.lua"
+				DELETE_BYTES 0x0 BUFFER_LENGTH
+				INSERT_BYTES 0x0 STRING_LENGTH "-- Functions to be invoked via op402 --%WNL%%WNL%"
+				WRITE_ASCII 0x0 "-- Functions to be invoked via op402 --%WNL%%WNL%"
+			BUT_ONLY_IF_IT_CHANGES
+		END
+		COPY_EXISTING "m_gt#402.lua" "override"
+			APPEND_FILE TEXT "cdtweaks\luke\lua\spontaneous_casting.lua"
+		BUT_ONLY UNLESS "^function GTSPCST[1-2]"
+	END
+	//
+	ACTION_CLEAR_ARRAY "cure_cause_wounds"
+	ACTION_DEFINE_ASSOCIATIVE_ARRAY "cure_cause_wounds" BEGIN
+		"%CLERIC_CURE_LIGHT_WOUNDS%" , "gtspc01a" , "MASK_GOOD" => "gtspc01b"
+		"%CLERIC_CURE_MODERATE_WOUNDS%" , "gtspc02a" , "MASK_GOOD" => "gtspc02b"
+		"%CLERIC_CURE_MEDIUM_WOUNDS%" , "gtspc03a" , "MASK_GOOD" => "gtspc03b"
+		"%CLERIC_CURE_SERIOUS_WOUNDS%" , "gtspc04a" , "MASK_GOOD" => "gtspc04b"
+		"%CLERIC_CURE_CRITICAL_WOUNDS%" , "gtspc05a" , "MASK_GOOD" => "gtspc05b"
+		//
+		"%CLERIC_CAUSE_LIGHT_WOUNDS%" , "gtspc06a" , "MASK_EVIL" => "gtspc06b"
+		"%CLERIC_CAUSE_MODERATE_WOUNDS%" , "gtspc07a" , "MASK_EVIL" => "gtspc07b"
+		"%CLERIC_CAUSE_MEDIUM_WOUNDS%" , "gtspc08a" , "MASK_EVIL" => "gtspc08b"
+		"%CLERIC_CAUSE_SERIOUS_WOUNDS%" , "gtspc09a" , "MASK_EVIL" => "gtspc09b"
+		"%CLERIC_CAUSE_CRITICAL_WOUNDS%" , "gtspc10a" , "MASK_EVIL" => "gtspc10b"
+	END
+	//
+	ACTION_PHP_EACH "cure_cause_wounds" AS "key" => "value" BEGIN
+		WITH_SCOPE BEGIN
+			COPY_EXISTING "%key_0%.spl" "override\%key_1%.spl"
+				// Header
+				WRITE_SHORT 0x1C 4 // type: innate
+				READ_LONG 0x34 "spellLevel"
+				WRITE_LONG 0x34 1 // level
+				// Extended Header
+				PATCH_WITH_SCOPE BEGIN
+					GET_OFFSET_ARRAY "ab_array" SPL_V10_HEADERS
+					PHP_EACH "ab_array" AS "ab_ind" => "ab_off" BEGIN
+						PATCH_IF SHORT_AT ("%ab_off%" + 0x10) > 1 BEGIN
+							WRITE_BYTE "%ab_off%" 0xFF // mark it for later deletion
+						END ELSE BEGIN
+							WRITE_SHORT ("%ab_off%" + 0x2) 4 // Ability location: F13 (Special Ability)
+						END
+					END
+					LPF "DELETE_SPELL_HEADER" INT_VAR "header_type" = 0xFF END // enact deletion
+				END
+				// Feature blocks
+				LPF "DELETE_EFFECT" END // fresh start
+				// Decrement by 1 all memorized divine spells of level "%spellLevel%"
+				LPF "ADD_SPELL_CFEFFECT" INT_VAR "opcode" = 402 "target" = 1 "parameter1" = "%spellLevel%" STR_VAR "resource" = "GTSPCST1" END // Invoke Lua
+				// Castable-at-will
+				LPF "ADD_SPELL_CFEFFECT" INT_VAR "insert_point" = 0 "opcode" = 172 "target" = 1 "timing" = 1 STR_VAR "resource" = "%DEST_RES%" END // Remove
+				LPF "ADD_SPELL_CFEFFECT" INT_VAR "insert_point" = 1 "opcode" = 171 "target" = 1 "timing" = 1 STR_VAR "resource" = "%DEST_RES%" END // Give
+				//
+				LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 324 "target" = 1 "parameter1" = IDS_OF_SYMBOL ("align" "%key_2%") "parameter2" = 118 "special" = ("%key_2%" STR_EQ "MASK_GOOD") ? RESOLVE_STR_REF (@0) : RESOLVE_STR_REF (@1) STR_VAR "resource" = "%DEST_RES%" END // Immunity to resource and message
+				// Check if the caster has at least one divine spell of level "%spellLevel%" memorized; if not, prevent it from using this special ability (display a feedback string in the combat log)
+				LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 402 "target" = 1 "parameter1" = RESOLVE_STR_REF (@2) STR_VAR "resource" = "GTSPCST2" END // Invoke Lua
+				LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 326 "target" = 1 "timing" = 1 "parameter1" = IDS_OF_SYMBOL ("align" "%key_2%") "parameter2" = 108 STR_VAR "resource" = "%value%" END // Apply effects List
+			BUT_ONLY_IF_IT_CHANGES
+		END
+		//
+		WITH_SCOPE BEGIN
+			COPY_EXISTING "%key_0%.spl" "override\%value%.spl"
+				WRITE_LONG NAME1 "-1" // blank name
+				WRITE_SHORT 0x22 0 // blank casting animation
+				WRITE_ASCII 0x10 "" #8 // blank casting sound
+				//
+				LPF "ALTER_SPELL_HEADER" INT_VAR "speed" = 0 "range" = 0x7FFF "projectile" = IDS_OF_SYMBOL ("missile" "None") END
+				//
+				PATCH_MATCH "%SOURCE_RES%" WITH
+					"%CLERIC_CAUSE_SERIOUS_WOUNDS%" "%CLERIC_CAUSE_CRITICAL_WOUNDS%" WHEN GAME_IS "bgee bg2ee eet" BEGIN
+						LPF "DELETE_SPELL_EFFECT" INT_VAR "opcode_to_delete" = "-1" END
+					END
+					DEFAULT
+				END
+			BUT_ONLY_IF_IT_CHANGES
+			//
+			ACTION_MATCH "%key_0%" WITH
+				"%CLERIC_CAUSE_SERIOUS_WOUNDS%" WHEN GAME_IS "bgee bg2ee eet" BEGIN
+					COPY_EXISTING - "serious.itm" "override"
+						LPF "ITEM_EFFECT_TO_SPELL" INT_VAR "type" = 1 STR_VAR "new_itm_spl" = "%value%.spl" END
+					BUT_ONLY
+				END
+				"%CLERIC_CAUSE_CRITICAL_WOUNDS%" WHEN GAME_IS "bgee bg2ee eet" BEGIN
+					COPY_EXISTING - "critical.itm" "override"
+						LPF "ITEM_EFFECT_TO_SPELL" INT_VAR "type" = 1 STR_VAR "new_itm_spl" = "%value%.spl" END
+					BUT_ONLY
+				END
+				DEFAULT
+			END
+		END
+		//
+		WITH_SCOPE BEGIN
+			LAF "NAME_NUM_OF_SPELL_RES" STR_VAR "spell_res" = "%key_0%" RET "spell_name" END
+			OUTER_PATCH_SAVE "spell_name" "%spell_name%" BEGIN
+				REPLACE_TEXTUALLY CASE_INSENSITIVE EVALUATE_REGEXP "^cleric_" ""
+			END
+			ACTION_TO_UPPER "spell_name"
+			ACTION_TO_UPPER "key_1"
+			//
+			ACTION_PHP_EACH "cleric_clab_files" AS "clab" => "" BEGIN
+				COPY_EXISTING "%clab%.2da" "override"
+					COUNT_2DA_COLS "cols"
+					COUNT_2DA_ROWS "%cols%" "rows"
+					INSERT_2DA_ROW "%rows%" "%cols%" "CDTWEAKS_SPONTANEOUS_CASTING_%spell_name% GA_%key_1%"
+					// formatting
+					PRETTY_PRINT_2DA
+				BUT_ONLY
+			END
+		END
+	END
+END
+
+/*
+*****************************************************************************************************************
+** Helper function **
+*****************************************************************************************************************
+*/
+
+DEFINE_ACTION_FUNCTION "SPONTANEOUS_CASTING#GET_CLERIC_CLAB_FILES"
+RET_ARRAY
+	"cleric_clab_files"
+BEGIN
+	OUTER_TEXT_SPRINT $"cleric_clab_files"("clabpr01") "" // unkitted cleric
+	//
+	COPY_EXISTING - "kitlist.2da" "override"
+		COUNT_2DA_COLS "cols"
+		READ_2DA_ENTRIES_NOW "read_kitlist" "%cols%"
+		FOR ("i" = 1 ; "%i%" < "%read_kitlist%" ; "i" += 1) BEGIN // skip RESERVE row...
+			READ_2DA_ENTRY_FORMER "read_kitlist" "%i%" 8 "class"
+			PATCH_IF ("%class%" == IDS_OF_SYMBOL ("class" "cleric")) BEGIN
+				READ_2DA_ENTRY_FORMER "read_kitlist" "%i%" 5 "abilities"
+				TEXT_SPRINT $"cleric_clab_files"("%abilities%") ""
+			END
+		END
+	BUT_ONLY
+END

--- a/cdtweaks/luke/lua/spontaneous_casting.lua
+++ b/cdtweaks/luke/lua/spontaneous_casting.lua
@@ -1,0 +1,53 @@
+-- Decrement by 1 all memorized divine spells of level spellLevel (level specified by param1 of op402) --
+
+function GTSPCST1(effect, sprite) -- args: CGameEffect, CGameSprite
+	-- CGameEffect (this effect, i.e. op402)
+	local spellLevel = effect.m_effectAmount -- param1 of op402
+	-- CGameSprite (the target object this effect is attached to)
+	local spellLevelMemListArray = sprite.m_memorizedSpellsPriest
+	-- Get all clerical spells of level spellLevel
+	local memList = spellLevelMemListArray:getReference(spellLevel - 1) -- level starts from 0!!!
+	local alreadyDecreasedResrefs = {}
+	-- Initialize my custom var to 0
+	EEex_Sprite_SetLocalInt(sprite, "cdtweaksSpontaneousCasting", 0)
+	-- Cycle through all memorized divine spells of level spellLevel
+	EEex_Utility_IterateCPtrList(memList, function(memInstance)
+		local memInstanceResref = memInstance.m_spellId:get() -- We need to use :get() to export a CResRef field as a Lua string!
+		if not alreadyDecreasedResrefs[memInstanceResref] then
+			local memFlags = memInstance.m_flags
+			if EEex_IsBitSet(memFlags, 0) then
+				memInstance.m_flags = EEex_UnsetBit(memFlags, 0)
+				-- Set my custom var to 1, meaning that at least one divine spell of level spellLevel is memorized
+				EEex_Sprite_SetLocalInt(sprite, "cdtweaksSpontaneousCasting", 1)
+				-- Make sure the engine catches the change
+				EEex_RunWithStackManager({
+					{ ["name"] = "abilityId", ["struct"] = "CAbilityId" } },
+					function(manager)
+						local abilityId = manager:getUD("abilityId")
+						abilityId.m_itemType = 1 -- spell, not an item
+						abilityId.m_res:set(memInstanceResref)
+						-- CAbilityId* ab, short changeAmount, int remove, int removeSpellIfZero
+						sprite:CheckQuickLists(abilityId, -1, 0, 0)
+					end
+				)
+				alreadyDecreasedResrefs[memInstanceResref] = true
+			end
+		end
+	end)
+end
+
+-- Check if the caster has at least one divine spell of level spellLevel memorized (feedback string specified by param1 of op402) --
+
+function GTSPCST2(effect, sprite) -- args: CGameEffect, CGameSprite
+	local parentResRef = effect.m_sourceRes:get() -- We need to use :get() to export a CResRef field as a Lua string!
+	local feedbackString = effect.m_effectAmount -- param1 of op402
+	--
+	if EEex_Sprite_GetLocalInt(sprite, "cdtweaksSpontaneousCasting") ~= 1 then
+		EEex_GameObject_ApplyEffect(sprite,
+		{
+			["effectID"] = 206, -- Protection from spell
+			["effectAmount"] = feedbackString,
+			["res"] = parentResRef,
+		})
+	end
+end

--- a/cdtweaks/luke/misc.tph
+++ b/cdtweaks/luke/misc.tph
@@ -139,3 +139,49 @@ BEGIN
 		READ_ASCII ("%base_off%" + "%off%") "string" ("%length%")
 	BUT_ONLY_IF_IT_CHANGES
 END
+
+////\\\\////\\\\////\\\\////\\\\////\\\\////\\\\////\\\\////\\\\////\\\\
+// Set a var for each entry in "spell.ids" \\
+////\\\\////\\\\////\\\\////\\\\////\\\\////\\\\////\\\\////\\\\////\\\\
+
+DEFINE_ACTION_MACRO "READ_SPELL_IDS"
+BEGIN
+	LOCAL_SET "cols" = 0
+	LOCAL_SET "read_spell" = 0
+	LOCAL_SET "i" = 0
+	LOCAL_SPRINT "identifier" ""
+	LOCAL_SPRINT "spell_res" ""
+	// The following variables are all set by `COPY_EXISTING`
+	LOCAL_SPRINT "SOURCE_DIRECTORY" ""
+	LOCAL_SPRINT "SOURCE_FILESPEC" ""
+	LOCAL_SPRINT "SOURCE_FILE" ""
+	LOCAL_SPRINT "SOURCE_RES" ""
+	LOCAL_SPRINT "SOURCE_EXT" ""
+	LOCAL_SET "SOURCE_SIZE" = 0
+	LOCAL_SPRINT "DEST_DIRECTORY" ""
+	LOCAL_SPRINT "DEST_FILESPEC" ""
+	LOCAL_SPRINT "DEST_FILE" ""
+	LOCAL_SPRINT "DEST_RES" ""
+	LOCAL_SPRINT "DEST_EXT" ""
+	// Main
+	COPY_EXISTING - "spell.ids" "override"
+		COUNT_2DA_COLS "cols"
+		READ_2DA_ENTRIES_NOW "read_spell" "%cols%"
+		FOR ("i" = 0; "%i%" < "%read_spell%"; "i" += 1) BEGIN
+			READ_2DA_ENTRY_FORMER "read_spell" "%i%" 1 "identifier"
+			PATCH_IF ("%identifier%" STRING_COMPARE_CASE "V1.0") BEGIN // skip 1st row ~IDS V1.0~ if needed (so as to avoid checking "spell_num" = "-1")
+				LPF "RES_NAME_OF_SPELL_NUM"
+				INT_VAR
+					"spell_num" = IDS_OF_SYMBOL (~SPELL~ ~%identifier%~)
+				RET
+					"spell_res"
+				END
+				// BG(2):EE => we'd like to discard false positive such as `2610 WIZARD_MONSTER_SUMMONING_4`, where the corresponding file ~SPWI610.SPL~ does not exist
+				// That is, make sure that ~%spell_res%.spl~ does exist as a game resource
+				PATCH_IF (FILE_EXISTS_IN_GAME ~%spell_res%.spl~) BEGIN
+					TEXT_SPRINT "%identifier%" "%spell_res%"
+				END
+			END
+		END
+	BUT_ONLY_IF_IT_CHANGES
+END

--- a/cdtweaks/readme-cdtweaks.html
+++ b/cdtweaks/readme-cdtweaks.html
@@ -976,6 +976,20 @@
 
         The aforementioned special events can occur only upon quaffing potions. As a result, there is no risk in using 1 Oil (f.i. Oil of Speed) and 1 Potion, as oils are applied to the skin, not consumed, so they wouldn't mix.
       </p>
+      <p> <strong>Spontaneous Casting for Clerics [Luke]</strong><br />
+        <em><abbr title="Enhanced Edition">EEex</abbr></em></p>
+      <p> This component aims at giving Clerics some Spontaneous Casting capabilities.
+        As a result, after installing this component, Clerics will be able to spontaneously cast the "cure" and "cause" spells (from light to critical wounds), which will consume a readied spell slot of the appropriate level.</br></br>
+        
+        As a completely artificial example, suppose a Cleric has the following level 1 spells memorized: Armor of Faith, Armor of Faith, Bless. Even if Cure Light Wounds is missing, it will still be able to cast it! Upon casting it, all level 1 spells memorized will be decremented by one, meaning that it will end up with only Armor of Faith memorized (in other words, it can "sacrifice" one of the two Armor of Faith and Bless to spontaneously cast Cure Light Wounds).<br><br>
+      
+        On top of that, note that:
+        <ul>
+          <li>only good-aligned Clerics can spontaneously cast the "cure" wounds spells</li>
+          <li>only evil-aligned Clerics can spontaneously cast the "cause" wounds spells</li>
+        </ul>
+        As a result, neutral-aligned Clerics are unaffected by this mechanic.
+      </p>
     </div>
     <div class="ribbon_rectangle_h3">
       <h3> <a id="contents_convenience" name="contents_convenience"></a>Convenience Tweaks and/or Cheats </h3>

--- a/cdtweaks/setup-cdtweaks.tp2
+++ b/cdtweaks/setup-cdtweaks.tp2
@@ -2635,6 +2635,25 @@ REQUIRE_PREDICATE GAME_IS ~bgee bg2ee eet iwdee~ @25
 REQUIRE_PREDICATE FILE_EXISTS ~cdtweaks/languages/%LANGUAGE%/pnp_potions.tra~ @7
 LABEL ~cd_tweaks_pnp_potions~
 
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////                                                            \\\\\
+///// Spontaneous Casting for Clerics                            \\\\\
+/////                                                            \\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+
+BEGIN @265000 DESIGNATED 2650
+GROUP @9
+REQUIRE_PREDICATE GAME_IS ~bgee bg2ee eet iwdee~ @25
+REQUIRE_PREDICATE MOD_IS_INSTALLED "EEex.tp2" 0 @29
+REQUIRE_PREDICATE RESOURCE_CONTAINS "spell.ids" "CLERIC_CAUSE_LIGHT_WOUNDS" @30
+REQUIRE_PREDICATE RESOURCE_CONTAINS "spell.ids" "CLERIC_CURE_MODERATE_WOUNDS" @30
+REQUIRE_PREDICATE RESOURCE_CONTAINS "spell.ids" "CLERIC_CAUSE_MODERATE_WOUNDS" @30
+REQUIRE_PREDICATE RESOURCE_CONTAINS "spell.ids" "CLERIC_CAUSE_MEDIUM_WOUNDS" @30
+REQUIRE_PREDICATE FILE_EXISTS ~cdtweaks/languages/%LANGUAGE%/spontaneous_casting.tra~ @7
+LABEL ~cd_tweaks_spontaneous_casting~
+
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////                                                  \\\\\


### PR DESCRIPTION
This component aims at giving Clerics some **Spontaneous Casting** capabilities.
As a result, after installing this component, Clerics will be able to spontaneously cast the "cure" and "cause" spells (from light to critical wounds), which will consume a readied spell slot of the appropriate level.

As a completely artificial example, suppose a Cleric has the following level `1` spells memorized: _Armor of Faith_, _Armor of Faith_, _Bless_. Even if _Cure Light Wounds_ is missing, it will still be able to cast it! Upon casting it, all level `1` spells memorized will be decremented by one, meaning that it will end up with only _Armor of Faith_ memorized (in other words, it can "sacrifice" one of the two _Armor of Faith_ and _Bless_ to spontaneously cast _Cure Light Wounds_).

On top of that, note that:
- only good-aligned Clerics can spontaneously cast the "cure" wounds spells
- only evil-aligned Clerics can spontaneously cast the "cause" wounds spells

As a result, neutral-aligned Clerics are unaffected by this mechanic.