### PR TITLE
Dual-Wield (part 2)

### DIFF
--- a/cdtweaks/luke/lua/dual_wield.lua
+++ b/cdtweaks/luke/lua/dual_wield.lua
@@ -35,7 +35,7 @@ function GTDLWLD(CGameEffect, CGameSprite)
 	local curThac0LeftPenalty = tonumber(EEex_Resource_GetAt2DALabels(stylbonu, "THAC0_LEFT", string.format("TWOWEAPON-%s", spriteProficiency2Weapon)))
 	-- reset var if either curThac0RightPenalty or curThac0LeftPenalty changes
 	if curThac0RightPenalty ~= CGameEffect.m_effectAmount2 or curThac0LeftPenalty ~= CGameEffect.m_effectAmount3 then
-		EEex_Sprite_SetLocalInt(CGameSprite, "cdtweaksDualWield", 0)
+		EEex_Sprite_SetLocalInt(CGameSprite, "cdtweaksDualWield", -1)
 		CGameEffect.m_effectAmount2 = curThac0RightPenalty -- store curThac0RightPenalty in param#3
 		CGameEffect.m_effectAmount3 = curThac0LeftPenalty -- store curThac0RightPenalty in param#4
 	end

--- a/cdtweaks/setup-cdtweaks.tp2
+++ b/cdtweaks/setup-cdtweaks.tp2
@@ -2741,7 +2741,7 @@ LABEL ~cd_tweaks_weapon_finesse~
 
 BEGIN @267000 DESIGNATED 2670
 GROUP @9
-REQUIRE_PREDICATE MOD_IS_INSTALLED ~EEex.tp2~ 0 @26
+REQUIRE_PREDICATE MOD_IS_INSTALLED ~EEex.tp2~ 0 @29
 REQUIRE_PREDICATE FILE_EXISTS ~cdtweaks/languages/%LANGUAGE%/dual_wield.tra~ @7
 LABEL ~cd_tweaks_dual_wield~
 


### PR DESCRIPTION
- Fix incorrect `tra` reference.
- Make sure the bonus from dual-wield is properly removed in case either `curThac0RightPenalty` or `curThac0LeftPenalty` changes.