### PR TITLE
NWN-ish Armor vs. Dexterity

### DIFF
--- a/cdtweaks/languages/english/nwn-ish_armor_vs_dex.tra
+++ b/cdtweaks/languages/english/nwn-ish_armor_vs_dex.tra
@@ -1,0 +1,1 @@
+@0 = "Medium or Heavy Armor Equipped"

--- a/cdtweaks/languages/english/weidu.tra
+++ b/cdtweaks/languages/english/weidu.tra
@@ -456,6 +456,8 @@ The uninstall messages above are normal and expected.
 
 @267000 = "Dual-Wield feat for Rangers [Luke]"
 
+@269000 = "NWN-ish Armor vs. Dexterity [Luke]"
+
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////                                                  \\\\\

--- a/cdtweaks/languages/italian/nwn-ish_armor_vs_dex.tra
+++ b/cdtweaks/languages/italian/nwn-ish_armor_vs_dex.tra
@@ -1,0 +1,1 @@
+@0 = "Armatura Media o Pesante Equipaggiata"

--- a/cdtweaks/lib/comp_2690.tpa
+++ b/cdtweaks/lib/comp_2690.tpa
@@ -1,0 +1,15 @@
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////                                                            \\\\\
+///// NWN-ish Armor vs. Dexterity                                \\\\\
+/////                                                            \\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+
+WITH_SCOPE BEGIN
+  INCLUDE "cdtweaks\luke\misc.tph"
+  INCLUDE "cdtweaks\lib\nwn-ish_armor_vs_dex.tph"
+  WITH_TRA "cdtweaks\languages\english\nwn-ish_armor_vs_dex.tra" "cdtweaks\languages\%LANGUAGE%\nwn-ish_armor_vs_dex.tra" BEGIN
+    LAF "NWN-ISH_ARMOR_VS_DEX" END
+  END
+END

--- a/cdtweaks/lib/nwn-ish_armor_vs_dex.tph
+++ b/cdtweaks/lib/nwn-ish_armor_vs_dex.tph
@@ -1,0 +1,24 @@
+DEFINE_ACTION_FUNCTION "NWN-ISH_ARMOR_VS_DEX"
+BEGIN
+	<<<<<<<< .../cdtweaks-inlined/empty
+	>>>>>>>>
+	//
+	ACTION_IF !(FILE_EXISTS_IN_GAME "gtmharmr.bam") BEGIN
+		COPY "cdtweaks\bam\gtmharmr.bam" "override"
+	END
+	//
+	WITH_SCOPE BEGIN
+		LAF "ADD_STATDESC_ENTRY" INT_VAR "description" = RESOLVE_STR_REF (@0) STR_VAR "bam_file" = "gtmharmr" RET "feedback_icon" = "index" END
+		// Listener: run 'func' each time a sprite has finished evaluating its effects
+		ACTION_IF !(FILE_EXISTS_IN_GAME "m_gtlstn.lua") BEGIN
+			COPY ".../cdtweaks-inlined/empty" "override\m_gtlstn.lua"
+				DELETE_BYTES 0x0 BUFFER_LENGTH
+				INSERT_BYTES 0x0 STRING_LENGTH "-- Listeners --%WNL%%WNL%"
+				WRITE_ASCII 0x0 "-- Listeners --%WNL%%WNL%"
+			BUT_ONLY_IF_IT_CHANGES
+		END
+		COPY_EXISTING "m_gtlstn.lua" "override"
+			APPEND_FILE_EVALUATE TEXT "cdtweaks\luke\lua\nwn-ish_armor_vs_dex.lua"
+		BUT_ONLY UNLESS "cdtweaksNWNArmor"
+	END
+END

--- a/cdtweaks/luke/lua/nwn-ish_armor_vs_dex.lua
+++ b/cdtweaks/luke/lua/nwn-ish_armor_vs_dex.lua
@@ -1,0 +1,87 @@
+-- cdtweaks: NWN-ish Armor vs. Dexterity --
+
+EEex_Opcode_AddListsResolvedListener(function(sprite)
+	-- internal function that applies the actual malus
+	local apply = function(ACMalus)
+		-- Update var
+		sprite:setLocalInt("cdtweaksNWNArmorHelper", ACMalus)
+		-- Mark the creature as 'malus applied'
+		sprite:setLocalInt("cdtweaksNWNArmor", 1)
+		--
+		sprite:applyEffect({
+			["effectID"] = 321, -- Remove effects by resource
+			["durationType"] = 1,
+			["res"] = "CDNWNARM",
+			["sourceID"] = sprite.m_id,
+			["sourceTarget"] = sprite.m_id,
+		})
+		sprite:applyEffect({
+			["effectID"] = 0, -- AC bonus
+			["durationType"] = 9,
+			["effectAmount"] = ACMalus,
+			["m_sourceRes"] = "CDNWNARM",
+			["sourceID"] = sprite.m_id,
+			["sourceTarget"] = sprite.m_id,
+		})
+		sprite:applyEffect({
+			["effectID"] = 142, -- Display portrait icon
+			["durationType"] = 9,
+			["dwFlags"] = %feedback_icon%,
+			["m_sourceRes"] = "CDNWNARM",
+			["sourceID"] = sprite.m_id,
+			["sourceTarget"] = sprite.m_id,
+		})
+	end
+	-- Check creature's equipment / stats
+	local items = sprite.m_equipment.m_items -- Array<CItem*,39>
+	--
+	local armor = items:get(1) -- CItem (index from "slots.ids")
+	local armorTypeStr = nil
+	local armorAnimation = nil
+	if armor then -- if the character is equipped with an armor...
+		local itemHeader = armor.pRes.pHeader -- Item_Header_st
+		armorTypeStr = GT_Resource_IDSToSymbol["itemcat"][itemHeader.itemType]
+		armorAnimation = EEex_CastUD(itemHeader.animationType, "CResRef"):get() -- certain engine types are nonsensical. We usually create fixups for the bindings whenever we run into them. We'll need to cast the value to properly read them
+	end
+	--
+	local dexmod = GT_Resource_2DA["dexmod"]
+	-- Since ``EEex_Opcode_AddListsResolvedListener`` is running after the effect lists have been evaluated, ``m_bonusStats`` has already been added to ``m_derivedStats`` by the engine
+	local spriteDEX = sprite.m_derivedStats.m_nDEX
+	--
+	local AC = tonumber(dexmod[string.format("%s", spriteDEX)]["AC"])
+	local ACMalus = nil
+	if armor then
+		if armorAnimation == "3A" then
+			ACMalus = math.floor(AC / 2)
+			if ACMalus == 0 then ACMalus = -1 end -- in case the base bonus is ``-1``, ``ACMalus`` should not be ``0``...
+		elseif armorAnimation == "4A" then
+			ACMalus = AC
+		end
+	end
+	-- if the character is wielding a medium or heavy armor ...
+	local applyCondition = AC < 0 and armor and armorTypeStr == "ARMOR" and (armorAnimation == "3A" or armorAnimation == "4A")
+	--
+	if sprite:getLocalInt("cdtweaksNWNArmor") == 0 then
+		if applyCondition then
+			apply(ACMalus)
+		end
+	else
+		if applyCondition then
+			-- Check if DEX has changed since the last application
+			if ACMalus ~= sprite:getLocalInt("cdtweaksNWNArmorHelper") then
+				apply(ACMalus)
+			end
+		else
+			-- Mark the creature as 'malus removed'
+			sprite:setLocalInt("cdtweaksNWNArmor", 0)
+			--
+			sprite:applyEffect({
+				["effectID"] = 321, -- Remove effects by resource
+				["durationType"] = 1,
+				["res"] = "CDNWNARM",
+				["sourceID"] = sprite.m_id,
+				["sourceTarget"] = sprite.m_id,
+			})
+		end
+	end
+end)

--- a/cdtweaks/readme-cdtweaks.html
+++ b/cdtweaks/readme-cdtweaks.html
@@ -1001,6 +1001,25 @@
       <p> <strong>Dual-Wield feat for Rangers [Luke]</strong><br />
         <em><abbr title="Enhanced Edition">EEex</abbr></em></p>
       <p> This component simply forces Rangers to wield light armors (or no armor) in order to benefit from Two-Weapon Fighting.</p>
+
+      <p> <strong>NWN-ish Armor vs. Dexterity [Luke]</strong><br />
+        <em><abbr title="Enhanced Edition">EEex</abbr></em></p>
+      <p> This component simply "forces" characters to wield light armors (or no armor) if they have high Dexterity.
+        In particular:
+        <ul>
+          <li>If a character is equipped with a Medium Armor, it will only benefit from half the bonus derived from its Dexterity (see <a href="https://gibberlings3.github.io/iesdp/files/2da/2da_bgee/dexmod.htm"><code>dexmod.2da</code></a>)
+            <ul>
+              <li>So for instance, a character with <code>18</code> DEX equipped with a Chain Mail Armor will suffer a <code>-4 / 2 = -2</code> AC penalty.</li>
+            </ul>
+          </li>
+          <li>If a character is equipped with a Heavy Armor, it will not benefit from the bonus derived from its Dexterity (see <a href="https://gibberlings3.github.io/iesdp/files/2da/2da_bgee/dexmod.htm"><code>dexmod.2da</code></a>)
+            <ul>
+              <li>So for instance, a character with <code>18</code> DEX equipped with a Plate Mail will suffer a <code>-4</code> AC penalty.</li>
+            </ul>
+          </li>
+        </ul>
+      </p>
+
     </div>
     <div class="ribbon_rectangle_h3">
       <h3> <a id="contents_convenience" name="contents_convenience"></a>Convenience Tweaks and/or Cheats </h3>

--- a/cdtweaks/setup-cdtweaks.tp2
+++ b/cdtweaks/setup-cdtweaks.tp2
@@ -2764,6 +2764,20 @@ REQUIRE_PREDICATE MOD_IS_INSTALLED ~EEex.tp2~ 0 @29
 REQUIRE_PREDICATE FILE_EXISTS ~cdtweaks/languages/%LANGUAGE%/dual_wield.tra~ @7
 LABEL ~cd_tweaks_dual_wield~
 
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////                                                            \\\\\
+///// NWN-ish Armor vs. Dexterity                                \\\\\
+/////                                                            \\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+
+BEGIN @269000 DESIGNATED 2690
+GROUP @9
+REQUIRE_PREDICATE MOD_IS_INSTALLED ~EEex.tp2~ 0 @29
+REQUIRE_PREDICATE FILE_EXISTS ~cdtweaks/languages/%LANGUAGE%/nwn-ish_armor_vs_dex.tra~ @7
+LABEL ~cd_tweaks_nwn-ish_armor_vs_dex~
+
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////                                                  \\\\\


### PR DESCRIPTION
This component simply "forces" characters to wield light armors (or no armor) if they have high Dexterity.
In particular:
- If a character is equipped with a **Medium Armor**, it will only benefit from half the bonus derived from its Dexterity (see <a href="https://gibberlings3.github.io/iesdp/files/2da/2da_bgee/dexmod.htm"><code>dexmod.2da</code></a>)
  - So for instance, a character with <code>18</code> DEX equipped with a Chain Mail Armor will suffer a <code>-4 / 2 = -2</code> AC penalty.
- If a character is equipped with a **Heavy Armor**, it will not benefit from the bonus derived from its Dexterity (see <a href="https://gibberlings3.github.io/iesdp/files/2da/2da_bgee/dexmod.htm"><code>dexmod.2da</code></a>)
  - So for instance, a character with <code>18</code> DEX equipped with a Plate Mail will suffer a <code>-4</code> AC penalty.