### PR TITLE
Defensive Roll

### DIFF
--- a/cdtweaks/languages/english/defensive_roll.tra
+++ b/cdtweaks/languages/english/defensive_roll.tra
@@ -1,0 +1,1 @@
+@0 = "Defensive Roll (Success) : The character takes only half damage from the blow"

--- a/cdtweaks/languages/english/defensive_roll.tra
+++ b/cdtweaks/languages/english/defensive_roll.tra
@@ -1,1 +1,1 @@
-@0 = "Defensive Roll (Success) : The character takes only half damage from the blow"
+@0 = "Defensive Roll : The character takes only half damage from the blow"

--- a/cdtweaks/languages/english/weidu.tra
+++ b/cdtweaks/languages/english/weidu.tra
@@ -456,6 +456,8 @@ The uninstall messages above are normal and expected.
 
 @267000 = "Dual-Wield feat for Rangers [Luke]"
 
+@270000 = "Defensive Roll feat for Thieves [Luke]"
+
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////                                                  \\\\\

--- a/cdtweaks/languages/italian/defensive_roll.tra
+++ b/cdtweaks/languages/italian/defensive_roll.tra
@@ -1,0 +1,1 @@
+@0 = "Tiro Difensivo (Successo) : Il personaggio subisce solo la metà dei danni inflitti dal colpo"

--- a/cdtweaks/languages/italian/defensive_roll.tra
+++ b/cdtweaks/languages/italian/defensive_roll.tra
@@ -1,1 +1,1 @@
-@0 = "Tiro Difensivo (Successo) : Il personaggio subisce solo la metà dei danni inflitti dal colpo"
+@0 = "Tiro Difensivo : Il personaggio subisce solo la metà dei danni inflitti dal colpo"

--- a/cdtweaks/lib/comp_2700.tpa
+++ b/cdtweaks/lib/comp_2700.tpa
@@ -1,0 +1,15 @@
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////                                                            \\\\\
+///// Defensive Roll feat for Thieves                            \\\\\
+/////                                                            \\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+
+WITH_SCOPE BEGIN
+  INCLUDE "cdtweaks\luke\misc.tph"
+  INCLUDE "cdtweaks\lib\defensive_roll.tph"
+  WITH_TRA "cdtweaks\languages\english\defensive_roll.tra" "cdtweaks\languages\%LANGUAGE%\defensive_roll.tra" BEGIN
+    LAF "DEFENSIVE_ROLL" END
+  END
+END

--- a/cdtweaks/lib/defensive_roll.tph
+++ b/cdtweaks/lib/defensive_roll.tph
@@ -36,7 +36,7 @@ BEGIN
 			INSERT_BYTES 0x72 0x28
 			/* Extended Header */
 			WRITE_SHORT 0x74 4 // Ability location: F12 (Special Ability)
-			WRITE_BYTE 0x7e 5 // Ability target: Caster
+			WRITE_BYTE 0x7E 5 // Ability target: Caster
 			WRITE_SHORT 0x80 30 // Ability range
 			WRITE_SHORT 0x82 1 // Minimum level
 			WRITE_SHORT 0x98 IDS_OF_SYMBOL ("MISSILE" "None") // Projectile

--- a/cdtweaks/lib/defensive_roll.tph
+++ b/cdtweaks/lib/defensive_roll.tph
@@ -1,0 +1,63 @@
+DEFINE_ACTION_FUNCTION "DEFENSIVE_ROLL"
+BEGIN
+	LAF "GET_CLAB_FILES" STR_VAR "class" = "thief" RET_ARRAY "clab_files" END
+	//
+	<<<<<<<< .../cdtweaks-inlined/empty
+	>>>>>>>>
+	//
+	WITH_SCOPE BEGIN
+		ACTION_IF !(FILE_EXISTS_IN_GAME "m_gt#403.lua") BEGIN
+			COPY ".../cdtweaks-inlined/empty" "override\m_gt#403.lua"
+				DELETE_BYTES 0x0 BUFFER_LENGTH
+				INSERT_BYTES 0x0 STRING_LENGTH "-- Functions to be invoked via op403 --%WNL%%WNL%"
+				WRITE_ASCII 0x0 "-- Functions to be invoked via op403 --%WNL%%WNL%"
+			BUT_ONLY_IF_IT_CHANGES
+		END
+		COPY_EXISTING "m_gt#403.lua" "override"
+			SET "feedback_strref" = RESOLVE_STR_REF (@0)
+			APPEND_FILE_EVALUATE TEXT "cdtweaks\luke\lua\defensive_roll.lua"
+		BUT_ONLY UNLESS "^function GTDEFRLL"
+	END
+	//
+	WITH_SCOPE BEGIN
+		CREATE "spl" "cddefrll"
+		COPY_EXISTING "cddefrll.spl" "override"
+			/* Header */
+			WRITE_LONG NAME1 "-1"
+			WRITE_LONG NAME2 ~-1~
+			WRITE_LONG 0x18 BIT14 // Ignore dead/wild magic
+			WRITE_SHORT 0x1C 4 // Type: Innate
+			WRITE_LONG UNIDENTIFIED_DESC "-1"
+			WRITE_LONG DESC ~-1~
+			WRITE_LONG 0x34 1 // Level
+			WRITE_LONG 0x64 0x72 // Extended Header offset
+			WRITE_SHORT 0x68 1 // Extended Header count
+			WRITE_LONG 0x6A 0x9A // Feature Block Table offset
+			INSERT_BYTES 0x72 0x28
+			/* Extended Header */
+			WRITE_SHORT 0x74 4 // Ability location: F12 (Special Ability)
+			WRITE_BYTE 0x7e 5 // Ability target: Caster
+			WRITE_SHORT 0x80 30 // Ability range
+			WRITE_SHORT 0x82 1 // Minimum level
+			WRITE_SHORT 0x98 IDS_OF_SYMBOL ("MISSILE" "None") // Projectile
+			/* Feature blocks */
+			LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 403 "target" = 1 "timing" = 9 STR_VAR "resource" = "GTDEFRLL" END // Screen Effects
+		BUT_ONLY
+	END
+	//
+	LAF "ADD_EXTENDED_STAT" STR_VAR "identifier" = "CDTWEAKS_DEFENSIVE_ROLL" END
+	//
+	WITH_SCOPE BEGIN
+		ACTION_PHP_EACH "clab_files" AS "clab" => "" BEGIN
+			COPY_EXISTING "%clab%.2da" "override"
+				PATCH_MATCH "%DEST_RES%" WITH
+					"clabth05" BEGIN // Shadowdancer
+						LPF "ADD_CLAB_ABILITY" INT_VAR "level" = 5 STR_VAR "identifier" = "CDTWEAKS_DEFENSIVE_ROLL" "resref" = "cddefrll" END
+					END
+					DEFAULT // Not Shadowdancer
+						LPF "ADD_CLAB_ABILITY" INT_VAR "level" = 10 STR_VAR "identifier" = "CDTWEAKS_DEFENSIVE_ROLL" "resref" = "cddefrll" END
+				END
+			BUT_ONLY
+		END
+	END
+END

--- a/cdtweaks/luke/lua/defensive_roll.lua
+++ b/cdtweaks/luke/lua/defensive_roll.lua
@@ -1,0 +1,56 @@
+-- cdtweaks: Defensive Roll feat for rogues --
+
+function GTDEFRLL(op403CGameEffect, CGameEffect, CGameSprite)
+	local damageTypeStr = GT_Resource_IDSToSymbol["dmgtype"][CGameEffect.m_dWFlags]
+	local damageAmount = CGameEffect.m_effectAmount
+	--
+	local spriteFlags = CGameSprite.m_baseStats.m_flags
+	--
+	local spriteHP = CGameSprite.m_baseStats.m_hitPoints
+	--
+	local spriteState = CGameSprite.m_baseStats.m_generalState
+	local state = GT_Resource_SymbolToIDS["state"]
+	--
+	local stats = GT_Resource_SymbolToIDS["stats"]
+	--
+	local spriteSaveVSBreath = CGameSprite.m_derivedStats.m_nSaveVSBreath + CGameSprite.m_bonusStats.m_nSaveVSBreath
+	--
+	local spriteLevel1 = CGameSprite.m_derivedStats.m_nLevel1 + CGameSprite.m_bonusStats.m_nLevel1
+	local spriteLevel2 = CGameSprite.m_derivedStats.m_nLevel2 + CGameSprite.m_bonusStats.m_nLevel2
+	--
+	local spriteClassStr = GT_Resource_IDSToSymbol["class"][CGameSprite.m_typeAI.m_Class]
+	--
+	local roll = Infinity_RandomNumber(1, 20) -- 1d20
+	-- If the character is struck by a potentially lethal blow, he makes a save vs. breath. If successful, he takes only half damage from the blow.
+	if CGameEffect.m_effectId == 0xC and damageTypeStr ~= "STUNNING" and CGameEffect.m_slotNum == -1 and CGameEffect.m_sourceType == 0 and CGameEffect.m_sourceRes:get() == "" -- base weapon damage (all damage types but STUNNING)
+		and (spriteClassStr == "THIEF" or spriteClassStr == "FIGHTER_MAGE_THIEF"
+			-- incomplete dual-class characters should not benefit from Defensive Roll
+			or (spriteClassStr == "FIGHTER_THIEF" and (EEex_IsBitUnset(spriteFlags, 0x6) or spriteLevel1 > spriteLevel2))
+			or (spriteClassStr == "MAGE_THIEF" and (EEex_IsBitUnset(spriteFlags, 0x6) or spriteLevel1 > spriteLevel2))
+			or (spriteClassStr == "CLERIC_THIEF" and (EEex_IsBitUnset(spriteFlags, 0x6) or spriteLevel1 > spriteLevel2)))
+		and EEex_BAnd(spriteState, state["CD_STATE_NOTVALID"]) == 0
+		and spriteSaveVSBreath <= roll
+		and damageAmount >= spriteHP
+		and EEex_Sprite_GetExtendedStat(CGameSprite, stats["CDTWEAKS_DEFENSIVE_ROLL"]) == 0
+	then
+		CGameEffect.m_effectAmount = math.floor(damageAmount / 2)
+		EEex_GameObject_ApplyEffect(CGameSprite,
+		{
+			["effectID"] = 139, -- Display string
+			["durationType"] = 1,
+			["effectAmount"] = %feedback_strref%,
+			["sourceID"] = op403CGameEffect.m_sourceId, -- Certain opcodes (see f.i. op326) use this field internally... it's probably a good idea to always specify it...
+			["sourceTarget"] = op403CGameEffect.m_sourceTarget, -- Certain opcodes (see f.i. op326) use this field internally... it's probably a good idea to always specify it...
+		})
+		EEex_GameObject_ApplyEffect(CGameSprite,
+		{
+			["effectID"] = 401, -- Set extended stat
+			["duration"] = 7200,
+			["special"] = stats["CDTWEAKS_DEFENSIVE_ROLL"],
+			["dwFlags"] = 1, -- set
+			["effectAmount"] = 1,
+			["sourceID"] = op403CGameEffect.m_sourceId, -- Certain opcodes (see f.i. op326) use this field internally... it's probably a good idea to always specify it...
+			["sourceTarget"] = op403CGameEffect.m_sourceTarget, -- Certain opcodes (see f.i. op326) use this field internally... it's probably a good idea to always specify it...
+		})
+	end
+end

--- a/cdtweaks/luke/lua/defensive_roll.lua
+++ b/cdtweaks/luke/lua/defensive_roll.lua
@@ -4,8 +4,6 @@ function GTDEFRLL(op403CGameEffect, CGameEffect, CGameSprite)
 	local damageTypeStr = GT_Resource_IDSToSymbol["dmgtype"][CGameEffect.m_dWFlags]
 	local damageAmount = CGameEffect.m_effectAmount
 	--
-	local spriteFlags = CGameSprite.m_baseStats.m_flags
-	--
 	local spriteHP = CGameSprite.m_baseStats.m_hitPoints
 	--
 	local spriteState = CGameSprite.m_baseStats.m_generalState
@@ -15,19 +13,9 @@ function GTDEFRLL(op403CGameEffect, CGameEffect, CGameSprite)
 	--
 	local spriteSaveVSBreath = CGameSprite.m_derivedStats.m_nSaveVSBreath + CGameSprite.m_bonusStats.m_nSaveVSBreath
 	--
-	local spriteLevel1 = CGameSprite.m_derivedStats.m_nLevel1 + CGameSprite.m_bonusStats.m_nLevel1
-	local spriteLevel2 = CGameSprite.m_derivedStats.m_nLevel2 + CGameSprite.m_bonusStats.m_nLevel2
-	--
-	local spriteClassStr = GT_Resource_IDSToSymbol["class"][CGameSprite.m_typeAI.m_Class]
-	--
 	local roll = Infinity_RandomNumber(1, 20) -- 1d20
 	-- If the character is struck by a potentially lethal blow, he makes a save vs. breath. If successful, he takes only half damage from the blow.
 	if CGameEffect.m_effectId == 0xC and damageTypeStr ~= "STUNNING" and CGameEffect.m_slotNum == -1 and CGameEffect.m_sourceType == 0 and CGameEffect.m_sourceRes:get() == "" -- base weapon damage (all damage types but STUNNING)
-		and (spriteClassStr == "THIEF" or spriteClassStr == "FIGHTER_MAGE_THIEF"
-			-- incomplete dual-class characters should not benefit from Defensive Roll
-			or (spriteClassStr == "FIGHTER_THIEF" and (EEex_IsBitUnset(spriteFlags, 0x6) or spriteLevel1 > spriteLevel2))
-			or (spriteClassStr == "MAGE_THIEF" and (EEex_IsBitUnset(spriteFlags, 0x6) or spriteLevel1 > spriteLevel2))
-			or (spriteClassStr == "CLERIC_THIEF" and (EEex_IsBitUnset(spriteFlags, 0x6) or spriteLevel1 > spriteLevel2)))
 		and EEex_BAnd(spriteState, state["CD_STATE_NOTVALID"]) == 0
 		and spriteSaveVSBreath <= roll
 		and damageAmount >= spriteHP

--- a/cdtweaks/luke/misc.tph
+++ b/cdtweaks/luke/misc.tph
@@ -187,6 +187,7 @@ BEGIN
 
 END
 
+////\\\\////\\\\////\\\\////\\\\////\\\\////\\\\////\\\\////\\\\////\\\\
 // Get the clab files of all kits whose base class is "%class%" \\
 ////\\\\////\\\\////\\\\////\\\\////\\\\////\\\\////\\\\////\\\\////\\\\
 
@@ -221,4 +222,88 @@ BEGIN
 		END
 	BUT_ONLY
   
+END
+
+////\\\\////\\\\////\\\\////\\\\////\\\\////\\\\////\\\\////\\\\////\\\\
+// Add the specified ability to the current clab file \\
+////\\\\////\\\\////\\\\////\\\\////\\\\////\\\\////\\\\////\\\\////\\\\
+
+DEFINE_PATCH_FUNCTION "ADD_CLAB_ABILITY"
+INT_VAR
+	"level" = 1
+STR_VAR
+	"type" = "ap" // default: passive ability
+	"resref" = ""
+	"identifier" = "GT_EXAMPLE"
+BEGIN
+	// Sanity checks
+	PATCH_IF ("%level%" <= 0) BEGIN
+		PATCH_FAIL "ADD_CLAB_ABILITY: level must be strictly greater than 0"
+	END
+	PATCH_IF ("%resref%" STRING_EQUAL_CASE "") BEGIN
+		PATCH_FAIL "ADD_CLAB_ABILITY: resref cannot be empty"
+	END
+	//
+	TO_UPPER "type"
+	TO_UPPER "resref"
+	TO_UPPER "identifier"
+	// Main
+	TEXT_SPRINT "string" "%identifier%"
+	FOR ("i" = 1 ; "%i%" <= "%level%" ; "i" += 1) BEGIN
+		PATCH_IF ("%i%" == "%level%") BEGIN
+			TEXT_SPRINT "string" "%string% %type%_%resref%"
+		END ELSE BEGIN
+			TEXT_SPRINT "string" "%string% ****"
+		END
+	END
+	// Add row
+	COUNT_2DA_COLS "cols"
+	COUNT_2DA_ROWS "%cols%" "rows"
+	INSERT_2DA_ROW "%rows%" "%cols%" "%string%"
+	// formatting
+	PRETTY_PRINT_2DA
+END
+
+/*
+=====================================================================================================
+**ADD_EXTENDED_STAT**
+- For use with EEex (https://eeex-docs.readthedocs.io/en/latest/EEex%20Opcodes/index.html#opcode-401)
+=====================================================================================================
+*/
+
+DEFINE_DIMORPHIC_FUNCTION "ADD_EXTENDED_STAT"
+INT_VAR
+	"min" = 0 // for use in "x-stats.2da"
+	"max" = 1 // for use in "x-stats.2da"
+	"default" = 0 // for use in "x-stats.2da"
+STR_VAR
+	"identifier" = "" // for use in "stats.ids"
+RET
+	"value"
+BEGIN
+	OUTER_SET "value" = IDS_OF_SYMBOL ("stats" "%identifier%")
+	//
+	ACTION_IF ("%value%" == "-1") BEGIN
+		OUTER_PATCH ~~ BEGIN
+			FOR ("id" = 203 ; "%id%" <= 0xFFFF + 202 ; "id" += 1) BEGIN
+				LOOKUP_IDS_SYMBOL_OF_INT "symbol" ~stats~ "%id%"
+				PATCH_IF (~%symbol%~ STRING_EQUAL ~%id%~) BEGIN
+					SET "value" = "%id%"
+					SET "id" = 0xFFFF + 202 + 1 // Kill FOR-loop
+				END
+			END
+		END
+		//
+		ACTION_IF ("%value%" != "-1") BEGIN
+			APPEND "stats.ids" "%value% %identifier%"
+			//
+			APPEND "x-stats.2da" "%identifier% %min% %max% %default%"
+			// Formatting
+			COPY_EXISTING "x-stats.2da" "override"
+				PRETTY_PRINT_2DA
+			BUT_ONLY
+		END ELSE BEGIN
+			FAIL "ADD_EXTENDED_STAT: there's no room in ~stats.ids~ for appending ~%identifier%~"
+		END
+	END
 END

--- a/cdtweaks/readme-cdtweaks.html
+++ b/cdtweaks/readme-cdtweaks.html
@@ -1001,6 +1001,18 @@
       <p> <strong>Dual-Wield feat for Rangers [Luke]</strong><br />
         <em><abbr title="Enhanced Edition">EEex</abbr></em></p>
       <p> This component simply forces Rangers to wield light armors (or no armor) in order to benefit from Two-Weapon Fighting.</p>
+
+      <p> <strong>Defensive Roll feat for Thieves [Luke]</strong><br />
+        <em><abbr title="Enhanced Edition">EEex</abbr></em></p>
+      <p> This component aims at implementing the NWN feat Defensive Roll. As a result, after installing it, if the character is struck by a potentially lethal blow, he makes a Save vs. Breath. If successful, he takes only half damage from the blow.<br>
+        Notes:
+        <ul>
+          <li>This feat is only available to thieves (level 10) and Shadowdancers (level 5).</li>
+          <li>A "potentially lethal blow" refers to a standard attack with a weapon that would, if not for this feat, reduce the target below one hit point with just its physical damage.</li>
+          <li>Use: automatic, but limited to one use per day. Incapacitated characters cannot make a defensive roll.</li>
+        </ul>
+      </p>
+
     </div>
     <div class="ribbon_rectangle_h3">
       <h3> <a id="contents_convenience" name="contents_convenience"></a>Convenience Tweaks and/or Cheats </h3>

--- a/cdtweaks/setup-cdtweaks.tp2
+++ b/cdtweaks/setup-cdtweaks.tp2
@@ -2764,6 +2764,20 @@ REQUIRE_PREDICATE MOD_IS_INSTALLED ~EEex.tp2~ 0 @29
 REQUIRE_PREDICATE FILE_EXISTS ~cdtweaks/languages/%LANGUAGE%/dual_wield.tra~ @7
 LABEL ~cd_tweaks_dual_wield~
 
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////                                                            \\\\\
+///// Defensive Roll feat for Thieves                            \\\\\
+/////                                                            \\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
+
+BEGIN @270000 DESIGNATED 2700
+GROUP @9
+REQUIRE_PREDICATE MOD_IS_INSTALLED ~EEex.tp2~ 0 @29
+REQUIRE_PREDICATE FILE_EXISTS ~cdtweaks/languages/%LANGUAGE%/defensive_roll.tra~ @7
+LABEL ~cd_tweaks_defensive_roll~
+
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////                                                  \\\\\


### PR DESCRIPTION
This component aims at implementing the NWN feat **Defensive Roll**. As a result, after installing it, if the character is struck by a potentially lethal blow, he makes a Save vs. Breath. If successful, he takes only half damage from the blow.

Notes:
- This feat is only available to thieves (level 10) and Shadowdancers (level 5).
- A "potentially lethal blow" refers to a standard attack with a weapon that would, if not for this feat, reduce the target below one hit point with just its physical damage.
- Use: automatic, but limited to one use per day. Incapacitated characters cannot make a defensive roll.