### PR TITLE
Sneak Attack (Blackguards)

### DIFF
--- a/cdtweaks/languages/english/sneakatt_blackguard.tra
+++ b/cdtweaks/languages/english/sneakatt_blackguard.tra
@@ -1,0 +1,1 @@
+@0 = "Sneak Attack"

--- a/cdtweaks/languages/english/weidu.tra
+++ b/cdtweaks/languages/english/weidu.tra
@@ -464,6 +464,8 @@ The uninstall messages above are normal and expected.
 
 @271000 = "Divine Grace / Dark Blessing feat for Paladins / Blackguards [Luke]"
 
+@274000 = "Sneak Attack class feat for Blackguards [Luke]"
+
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////                                                  \\\\\

--- a/cdtweaks/languages/italian/sneakatt_blackguard.tra
+++ b/cdtweaks/languages/italian/sneakatt_blackguard.tra
@@ -1,0 +1,1 @@
+@0 = "Attacco Furtivo"

--- a/cdtweaks/languages/italian/weidu.tra
+++ b/cdtweaks/languages/italian/weidu.tra
@@ -419,6 +419,8 @@ o rimpiazzata da - un'altra facente parte di uno dei mods installati.~
 
 @271000 = "Grazia Divina / Benedizione Oscura per Paladini / Guardie Nere [Luke]"
 
+@274000 = "Aggiungi talento di classe Attacco Furtivo per Guardie Nere [Luke]"
+
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////                                                  \\\\\

--- a/cdtweaks/lib/comp_2740.tpa
+++ b/cdtweaks/lib/comp_2740.tpa
@@ -1,0 +1,16 @@
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////
+/////                                                                 /////
+///// Sneak Attack feat for Blackguards                               \\\\\
+/////                                                                 \\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////
+
+WITH_SCOPE BEGIN
+  INCLUDE "cdtweaks\luke\misc.tph"
+  INCLUDE "cdtweaks\ardanis\functions.tph"
+  INCLUDE "cdtweaks\lib\sneakatt_blackguard.tph"
+  WITH_TRA "cdtweaks\languages\english\sneakatt_blackguard.tra" "cdtweaks\languages\%LANGUAGE%\sneakatt_blackguard.tra" BEGIN
+    LAF "SNEAKATT_BLACKGUARD" END
+  END
+END

--- a/cdtweaks/lib/sneakatt_blackguard.tph
+++ b/cdtweaks/lib/sneakatt_blackguard.tph
@@ -1,0 +1,45 @@
+DEFINE_ACTION_FUNCTION "SNEAKATT_BLACKGUARD"
+BEGIN
+	CREATE "eff" "cdblkgsa"
+	COPY_EXISTING "cdblkgsa.eff" "override"
+		WRITE_LONG 0x10 402 // invoke lua
+		WRITE_SHORT 0x2C 100 // prob1
+		WRITE_ASCII 0x30 "GTBLKG01" #8 // lua function
+	BUT_ONLY
+	//
+	CREATE "spl" "cdblkgsa"
+	COPY_EXISTING "cdblkgsa.spl" "override"
+		WRITE_LONG NAME1 RESOLVE_STR_REF (@0)
+		WRITE_LONG 0x18 BIT14 // flags: ignore dead/wild magic
+		WRITE_SHORT 0x1C 4 // type: innate
+		WRITE_LONG 0x34 1 // level
+		//
+		LPF "ADD_SPELL_HEADER" INT_VAR "range" = 30 END
+		//
+		LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 324 "target" = 2 "parameter1" = IDS_OF_SYMBOL ("kit" "barbarian") "parameter2" = 109 STR_VAR "resource" = "%DEST_RES%" END // Immunity to resource and message
+		PATCH_WITH_SCOPE BEGIN
+			LPF "ADD_SPLPROT_ENTRY" INT_VAR "stat" = IDS_OF_SYMBOL ("STATS" "IMMUNITY_TO_BACKSTAB") STR_VAR "value" = "-1" "relation" = "4" "label" = "STAT(IMMUNITY_TO_BACKSTAB) >= n" RET "index" END
+			LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 324 "target" = 2 "parameter1" = 1 "parameter2" = "%index%" STR_VAR "resource" = "%DEST_RES%" END // Immunity to resource and message (IMMUNITY_TO_BACKSTAB >= 1)
+		END
+		LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 324 "target" = 2 "parameter1" = IDS_OF_SYMBOL ("general" "plant") "parameter2" = 103 STR_VAR "resource" = "%DEST_RES%" END // Immunity to resource and message
+		LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 324 "target" = 2 "parameter2" = 55 STR_VAR "resource" = "%DEST_RES%" END // Immunity to resource and message (RACE=GOLEM || GENERAL=UNDEAD)
+		LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 324 "target" = 2 "parameter1" = IDS_OF_SYMBOL ("general" "weapon") "parameter2" = 103 STR_VAR "resource" = "%DEST_RES%" END // Immunity to resource and message (Animated weapons such as the Mordenkainen's Sword)
+		PATCH_WITH_SCOPE BEGIN
+			PATCH_FOR_EACH "race" IN "mist" "dragon" "beholder" "slime" "demonic" "mephit" "imp" "elemental" "salamander" "genie" "solar" "antisolar" "planatar" "darkplanatar" BEGIN
+				LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 324 "target" = 2 "parameter1" = IDS_OF_SYMBOL ("race" "%race%") "parameter2" = 104 STR_VAR "resource" = "%DEST_RES%" END // Immunity to resource and message
+			END
+		END
+		//
+		LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 402 "target" = 2 STR_VAR "resource" = "GTBLKG02" END // invoke lua
+	BUT_ONLY_IF_IT_CHANGES
+	// Listener: run 'func' each time a sprite has finished evaluating its effects
+	LAF "APPEND_LUA_FUNCTION" STR_VAR "description" = "Listeners" "sourceFileSpec" = "cdtweaks\luke\lua\sneakatt_blackguard_grant.lua" "destRes" = "m_gtlstn" END
+	//
+	LAF "APPEND_LUA_FUNCTION" STR_VAR "description" = "Functions to be invoked via op402" "sourceFileSpec" = "cdtweaks\luke\lua\sneakatt_blackguard.lua" "destRes" = "m_gt#402" END
+	//
+	LAF "APPEND_LUA_FUNCTION" STR_VAR "description" = "Utility Functions / Listeners" "sourceFileSpec" = "cdtweaks\luke\lua\utility\is_invisible.lua" "destRes" = "m_gtutil" END
+	//
+	ACTION_IF !(FILE_EXISTS_IN_GAME "m_gttbls.lua") BEGIN
+		COPY "cdtweaks\luke\lua\m_gttbls.lua" "override"
+	END
+END

--- a/cdtweaks/luke/lua/m_gttbls.lua
+++ b/cdtweaks/luke/lua/m_gttbls.lua
@@ -7,7 +7,7 @@ GT_Resource_SymbolToIDS = {}
 EEex_GameState_AddInitializedListener(function()
 	-- 2DA
 	EEex_Utility_NewScope(function()
-		local resources = { "STRMOD", "STRMODEX", "DEXMOD", "STYLBONU" }
+		local resources = { "STRMOD", "STRMODEX", "DEXMOD", "STYLBONU", "SNEAKATT" }
 		--
 		for _, v in ipairs(resources) do
 			local data = EEex_Resource_Load2DA(v)

--- a/cdtweaks/luke/lua/sneakatt_blackguard.lua
+++ b/cdtweaks/luke/lua/sneakatt_blackguard.lua
@@ -1,0 +1,61 @@
+-- cdtweaks, Sneak Attack feat for Blackguards --
+
+function GTBLKG01(CGameEffect, CGameSprite)
+	local sourceSprite = EEex_GameObject_Get(CGameEffect.m_sourceId)
+	--
+	local targetGeneralState = CGameSprite.m_derivedStats.m_generalState + CGameSprite.m_bonusStats.m_generalState
+	-- limit to once per round
+	local getTimer = EEex_Trigger_ParseConditionalString('!GlobalTimerNotExpired("cdtweaksSneakattBlckgrdTimer","LOCALS")')
+	local setTimer = EEex_Action_ParseResponseString('SetGlobalTimer("cdtweaksSneakattBlckgrdTimer","LOCALS",6)')
+	--
+	if getTimer:evalConditionalAsAIBase(sourceSprite) then
+		-- if the target is incapacitated || the target is in combat with someone else || the blackguard is invisible
+		if not EEex_BAnd(targetGeneralState, 0x100029) == 0 or CGameSprite.m_targetId ~= sourceSprite.m_id or sourceSprite:getLocalInt("gtIsInvisible") == 1 then
+			setTimer:executeResponseAsAIBaseInstantly(sourceSprite)
+			--
+			CGameSprite:applyEffect({
+				["effectID"] = 146, -- Cast spell
+				["res"] = "GTBLKGSA", -- SPL file
+				["dwFlags"] = 1, -- cast instantly / ignore level
+				["sourceID"] = CGameEffect.m_sourceId,
+				["sourceTarget"] = CGameEffect.m_sourceTarget,
+			})
+		end
+	end
+	--
+	getTimer:free()
+	setTimer:free()
+end
+
+-- cdtweaks, Sneak Attack feat for Blackguards --
+
+function GTBLKG02(CGameEffect, CGameSprite)
+	local sneakatt = GT_Resource_2DA["sneakatt"]
+	--
+	local sourceSprite = EEex_GameObject_Get(CGameEffect.m_sourceId)
+	local sourceLevel = sourceSprite.m_derivedStats.m_nLevel1 + sourceSprite.m_bonusStats.m_nLevel1
+	--
+	local equipment = sourceSprite.m_equipment
+	local selectedWeapon = equipment.m_items:get(equipment.m_selectedWeapon)
+	local itemHeader = selectedWeapon.pRes.pHeader -- Item_Header_st
+	--
+	local itemAbility = EEex_Resource_GetItemAbility(itemHeader, equipment.m_selectedWeaponAbility) -- Item_ability_st
+	--
+	local randomValue = math.random(0, 1)
+	local damageType = {16, 0, 256, 128, 2048, 16 * randomValue, randomValue == 0 and 16 or 256, 256 * randomValue} -- piercing, crushing, slashing, missile, non-lethal, piercing/crushing, piercing/slashing, slashing/crushing
+	--
+	if damageType[itemAbility.damageType] and tonumber(sneakatt["STALKER"][string.format("%s", sourceLevel)]) > 0 then
+		EEex_GameObject_ApplyEffect(CGameSprite,
+		{
+			["effectID"] = 12, -- Damage
+			["dwFlags"] = damageType[itemAbility.damageType] * 0x10000, -- Normal
+			["durationType"] = 1,
+			["numDice"] = tonumber(sneakatt["STALKER"][string.format("%s", sourceLevel)]),
+			["diceSize"] = 6,
+			["m_sourceRes"] = CGameEffect.m_sourceRes:get(),
+			["m_sourceType"] = CGameEffect.m_sourceType,
+			["sourceID"] = CGameEffect.m_sourceId,
+			["sourceTarget"] = CGameEffect.m_sourceTarget,
+		})
+	end
+end

--- a/cdtweaks/luke/lua/sneakatt_blackguard_grant.lua
+++ b/cdtweaks/luke/lua/sneakatt_blackguard_grant.lua
@@ -1,0 +1,65 @@
+-- cdtweaks, Sneak Attack feat for Blackguards --
+
+EEex_Opcode_AddListsResolvedListener(function(sprite)
+	-- sanity check
+	if not EEex_GameObject_IsSprite(sprite) then
+		return
+	end
+	-- internal function that applies the actual bonus
+	local apply = function()
+		-- Mark the creature as 'feat applied'
+		sprite:setLocalInt("cdtweaksSneakattBlackguard", 1)
+		--
+		sprite:applyEffect({
+			["effectID"] = 321, -- Remove effects by resource
+			["durationType"] = 1,
+			["res"] = "GTBLKGSA",
+			["sourceID"] = sprite.m_id,
+			["sourceTarget"] = sprite.m_id,
+		})
+		sprite:applyEffect({
+			["effectID"] = 248, -- Melee hit effect
+			["res"] = "GTBLKGSA", -- EFF file
+			["durationType"] = 9,
+			["m_sourceRes"] = "GTBLKGSA",
+			["sourceID"] = sprite.m_id,
+			["sourceTarget"] = sprite.m_id,
+		})
+		sprite:applyEffect({
+			["effectID"] = 249, -- Ranged hit effect
+			["res"] = "GTBLKGSA", -- EFF file
+			["durationType"] = 9,
+			["m_sourceRes"] = "GTBLKGSA",
+			["sourceID"] = sprite.m_id,
+			["sourceTarget"] = sprite.m_id,
+		})
+	end
+	-- Check creature's class / kit / flags
+	local spriteFlags = sprite.m_baseStats.m_flags
+	local spriteClassStr = GT_Resource_IDSToSymbol["class"][sprite.m_typeAI.m_Class]
+	-- since ``EEex_Opcode_AddListsResolvedListener`` is running after the effect lists have been evaluated, ``m_bonusStats`` has already been added to ``m_derivedStats`` by the engine
+	local spriteKitStr = GT_Resource_IDSToSymbol["kit"][sprite.m_derivedStats.m_nKit]
+	-- Grant the feat to Blackguards (must not be fallen)
+	local applyAbility = spriteClassStr == "PALADIN" and spriteKitStr == "Blackguard" and EEex_IsBitUnset(spriteFlags, 9)
+	--
+	if sprite:getLocalInt("cdtweaksSneakattBlackguard") == 0 then
+		if applyAbility then
+			apply()
+		end
+	else
+		if applyAbility then
+			-- do nothing
+		else
+			-- Mark the creature as 'feat removed'
+			sprite:setLocalInt("cdtweaksSneakattBlackguard", 0)
+			--
+			sprite:applyEffect({
+				["effectID"] = 321, -- Remove effects by resource
+				["durationType"] = 1,
+				["res"] = "GTBLKGSA",
+				["sourceID"] = sprite.m_id,
+				["sourceTarget"] = sprite.m_id,
+			})
+		end
+	end
+end)

--- a/cdtweaks/luke/lua/utility/is_invisible.lua
+++ b/cdtweaks/luke/lua/utility/is_invisible.lua
@@ -1,0 +1,28 @@
+-- Utility: if a sprite is invisible, flag it (needed to implement custom sneak attacks) --
+
+EEex_Opcode_AddListsResolvedListener(function(sprite)
+	-- sanity check
+	if not EEex_GameObject_IsSprite(sprite) then
+		return
+	end
+	-- internal function that flags the creature
+	local apply = function()
+		sprite:setLocalInt("gtIsInvisible", 1)
+	end
+	-- Check state
+	-- since ``EEex_Opcode_AddListsResolvedListener`` is running after the effect lists have been evaluated, ``m_bonusStats`` has already been added to ``m_derivedStats`` by the engine
+	local spriteGeneralState = sprite.m_derivedStats.m_generalState
+	local applyCondition = EEex_IsBitSet(spriteGeneralState, 0x4) -- STATE_INVISIBLE (BIT4)
+	--
+	if sprite:getLocalInt("gtIsInvisible") == 0 then
+		if applyCondition then
+			apply()
+		end
+	else
+		if applyCondition then
+			-- do nothing
+		else
+			sprite:setLocalInt("gtIsInvisible", 0)
+		end
+	end
+end)

--- a/cdtweaks/luke/misc.tph
+++ b/cdtweaks/luke/misc.tph
@@ -310,3 +310,107 @@ BEGIN
 		END
 	END
 END
+
+/*
+============================================================================================================================================================================================================
+**ADD_SPLPROT_ENTRY** - Adds a new entry to "SPLPROT.2DA" and returns its index. If an identical entry already exists it will return the index of that entry instead (borrowed from Argent77, tweaked by me)
+============================================================================================================================================================================================================
+*/
+
+DEFINE_DIMORPHIC_FUNCTION "ADD_SPLPROT_ENTRY"
+INT_VAR
+	"stat"      = "-1" // a code from STATS.IDS or an extended stat code starting at 0x100 (256).
+STR_VAR
+	"value"     = "*" // either a numeric value that is evaluated by "stat", or a default value "*" for specific stats. Note: "-1" indicates a user-defined value.
+	"relation"  = "*" // specifies how to evaluate the value. Note: Not all extended stats require a relation code. Use "*" in this case.
+	"label"     = "" // user-friendly identifier
+RET
+	"index" // Entry number that can be used to refer to this operation in various effect opcodes. Returns "-1" on error.
+BEGIN
+	// Initialize
+	OUTER_SET "index" = "-1"
+	// Main
+	ACTION_IF ("%stat%" >= 0) BEGIN
+		OUTER_PATCH "" BEGIN
+			SPRINTF "valueHex" "%x" ("%stat%")
+		END
+		ACTION_IF (~%value%~ STRING_EQUAL ~~) BEGIN
+			OUTER_TEXT_SPRINT "value" ~*~
+		END
+		ACTION_IF (~%relation%~ STRING_EQUAL ~~) BEGIN
+			OUTER_TEXT_SPRINT "relation" ~*~
+		END
+		// Add the specified entry or return its index if already present
+		COPY_EXISTING ~splprot.2da~ ~override~
+			READ_2DA_ENTRIES_NOW "read_splprot" 4
+			// Search for identical entries
+			FOR ("idx" = 0; "%idx%" < "%read_splprot%"; "idx" += 1) BEGIN
+				READ_2DA_ENTRY_FORMER "read_splprot" "%idx%" 1 "curStat"
+				PATCH_IF (~%stat%~ STRING_EQUAL ~%curStat%~ OR ~%valueHex%~ STRING_EQUAL_CASE ~%curStat%~) BEGIN
+					READ_2DA_ENTRY_FORMER "read_splprot" "%idx%" 2 "curValue"
+					PATCH_IF (~%value%~ STRING_EQUAL ~%curValue%~) BEGIN
+						READ_2DA_ENTRY_FORMER "read_splprot" "%idx%" 3 "curRelation"
+						PATCH_IF (~%relation%~ STRING_EQUAL ~%curRelation%~) BEGIN
+							SET "index" = "%idx%" // If already present, return its index
+							SET "idx" = "%read_splprot%" // Kill FOR-loop
+						END
+					END
+				END
+			END
+			// If not already present, add it...
+			PATCH_IF ("%index%" < 0) BEGIN
+				// Make sure we provided an identifier!
+				PATCH_IF ("%label%" STRING_COMPARE_CASE "") BEGIN
+					// Sanity check
+					INNER_PATCH_SAVE "label" "%label%" BEGIN
+						REPLACE_TEXTUALLY CASE_INSENSITIVE EVALUATE_REGEXP "[ %TAB%%WNL%%MNL%%LNL%]" ""
+					END
+					// Add new entry
+					PATCH_IF ("%stat%" >= 0x100) BEGIN
+						TEXT_SPRINT "line" ~%read_splprot%_%label% %valueHex% %value% %relation%~
+					END ELSE BEGIN
+						TEXT_SPRINT "line" ~%read_splprot%_%label% %stat% %value% %relation%~
+					END
+					INSERT_2DA_ROW "%read_splprot%" 4 ~%line%~
+					// Prettify
+					PRETTY_PRINT_2DA
+					SET "index" = "%read_splprot%"
+				END ELSE BEGIN
+					PATCH_FAIL "ADD_SPLPROT_ENTRY: ~label~ cannot be empty. Please specify a human-friendly identifier (f.i. ~ALIGNMENTBITS!=MASK_LCNEUTRAL~)"
+				END
+			END
+		BUT_ONLY_IF_IT_CHANGES
+	END
+END
+
+/*
+=====================================================================================================
+**APPEND_LUA_FUNCTION**
+=====================================================================================================
+*/
+
+DEFINE_DIMORPHIC_FUNCTION "APPEND_LUA_FUNCTION"
+STR_VAR
+	"description" = "<MISSING DESCRIPTION ...>"
+	"sourceFileSpec" = "" // full path to lua file
+	"destRes" = "" // max 8-character string (must start with "m_")
+BEGIN
+	<<<<<<<< .../cdtweaks-inlined/empty
+	>>>>>>>>
+	//
+	ACTION_IF !(FILE_EXISTS_IN_GAME "%destRes%.lua") BEGIN
+		COPY ".../cdtweaks-inlined/empty" "override\%destRes%.lua"
+			DELETE_BYTES 0x0 BUFFER_LENGTH
+			INSERT_BYTES 0x0 STRING_LENGTH "-- %description% --%WNL%%WNL%"
+			WRITE_ASCII 0x0 "-- %description% --%WNL%%WNL%"
+		BUT_ONLY_IF_IT_CHANGES
+	END
+	//
+	COPY - "%sourceFileSpec%" "override"
+		READ_ASCII 0x0 "fileContent" (BUFFER_LENGTH)
+	BUT_ONLY
+	//
+	COPY_EXISTING "%destRes%.lua" "override"
+		APPEND_FILE_EVALUATE TEXT "%sourceFileSpec%"
+	BUT_ONLY UNLESS "%fileContent%"
+END

--- a/cdtweaks/readme-cdtweaks.html
+++ b/cdtweaks/readme-cdtweaks.html
@@ -1082,6 +1082,18 @@
         </ul>
       </p>
 
+      <p> <strong>Sneak Attack class feat for Blackguards [Luke]</strong><br />
+        <em><abbr title="Enhanced Edition">EEex</abbr></em></p>
+      <p> This component adds the passive feat Sneak Attack to Blackguards.<br>
+        Whenever the character makes a successful attack against an opponent who is incapacitated, cannot see them, or who is in combat with someone else, the character's blow delivers extra damage as if it was a <code>STALKER</code> of the same level (see <a href="https://gibberlings3.github.io/iesdp/files/2da/2da_bgee/sneakatt.htm"><code>sneakatt.2da</code></a>).<br>
+        Notes:
+        <ul>
+          <li>Use: automatic, but limited to once per round.</li>
+          <li>Creatures without discernible anatomies (see component <i>Make Certain Creatures Immune to Backstab/Sneak Attack</i> ) or that are otherwise immune to sneak attacks, either via spells/items or naturally (f.i. Barbarians), are unaffected by this feat.</li>
+          <li>Sneak attacks can be made with both melee and ranged weapons.</li>
+        </ul>
+      </p>
+
     </div>
     <div class="ribbon_rectangle_h3">
       <h3> <a id="contents_convenience" name="contents_convenience"></a>Convenience Tweaks and/or Cheats </h3>


### PR DESCRIPTION
This component adds the passive feat **Sneak Attack** to _Blackguards_.
Whenever the character makes a successful attack against an opponent who is incapacitated, cannot see them, or who is in combat with someone else, the character's blow delivers extra damage as if it was a `STALKER` of the same level (see [sneakatt.2da](https://gibberlings3.github.io/iesdp/files/2da/2da_bgee/sneakatt.htm)).

Notes:

- Use: automatic, but limited to once per round.
- Creatures without discernible anatomies (see component _Make Certain Creatures Immune to Backstab/Sneak Attack_) or that are otherwise immune to sneak attacks, either via spells/items or naturally (f.i. Barbarians), are unaffected by this feat.
- Sneak attacks can be made with both melee and ranged weapons.