### PR TITLE
Planar Turning class feat for Paladins and Clerics

### DIFF
--- a/cdtweaks/languages/english/planar_turning.tra
+++ b/cdtweaks/languages/english/planar_turning.tra
@@ -1,0 +1,2 @@
+@0 = "Turning Extraplanar Creatures"
+@1 = "Turned Extraplanar Creature"

--- a/cdtweaks/languages/english/weidu.tra
+++ b/cdtweaks/languages/english/weidu.tra
@@ -464,6 +464,8 @@ The uninstall messages above are normal and expected.
 
 @271000 = "Divine Grace / Dark Blessing feat for Paladins / Blackguards [Luke]"
 
+@277000 = "Planar Turning class feat for Clerics / Paladins [Luke]"
+
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////                                                  \\\\\

--- a/cdtweaks/languages/italian/planar_turning.tra
+++ b/cdtweaks/languages/italian/planar_turning.tra
@@ -1,0 +1,2 @@
+@0 = "Scacciare Creature Extraplanari"
+@1 = "Creatura Extraplanare Scacciata"

--- a/cdtweaks/languages/italian/weidu.tra
+++ b/cdtweaks/languages/italian/weidu.tra
@@ -419,6 +419,8 @@ o rimpiazzata da - un'altra facente parte di uno dei mods installati.~
 
 @271000 = "Grazia Divina / Benedizione Oscura per Paladini / Guardie Nere [Luke]"
 
+@277000 = "Aggiungi talento di classe Scacciare Creature Extraplanari per Paladini e Chierici [Luke]"
+
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////                                                  \\\\\

--- a/cdtweaks/lib/comp_2770.tpa
+++ b/cdtweaks/lib/comp_2770.tpa
@@ -1,0 +1,18 @@
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////
+/////                                                                 /////
+///// Planar Turning class feat for Paladins & Clerics                \\\\\
+/////                                                                 \\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////
+
+WITH_SCOPE BEGIN
+  INCLUDE "cdtweaks\luke\misc.tph"
+  INCLUDE "cdtweaks\ardanis\functions.tph"
+  //
+  INCLUDE "cdtweaks\lib\planar_turning.tph"
+  //
+  WITH_TRA "cdtweaks\languages\english\planar_turning.tra" "cdtweaks\languages\%LANGUAGE%\planar_turning.tra" BEGIN
+    LAF "PLANAR_TURNING" END
+  END
+END

--- a/cdtweaks/lib/planar_turning.tph
+++ b/cdtweaks/lib/planar_turning.tph
@@ -1,0 +1,26 @@
+DEFINE_ACTION_FUNCTION "PLANAR_TURNING"
+BEGIN
+	CREATE "spl" "cdplntrn"
+	COPY_EXISTING "cdplntrn.spl" "override"
+		WRITE_LONG NAME1 "-1"
+		WRITE_LONG 0x18 BIT14 // flags: ignore dead/wild magic
+		WRITE_SHORT 0x1C 4 // type: innate
+		WRITE_LONG 0x34 1 // level
+		//
+		LPF "ADD_SPELL_HEADER" INT_VAR "target" = 5 "range" = 30 "projectile" = IDS_OF_SYMBOL ("projectl" "INAREANP") + 1 END
+		//
+		LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 139 "target" = 1 "parameter1" = RESOLVE_STR_REF (@0) "timing" = 1 END // feedback message
+		LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 402 "target" = 2 STR_VAR "resource" = "GTPLNTRN" END // Invoke lua
+	BUT_ONLY_IF_IT_CHANGES
+	// Listener: run 'func' each time a sprite has finished evaluating its effects
+	LAF "APPEND_LUA_FUNCTION" STR_VAR "description" = "Listeners" "sourceFileSpec" = "cdtweaks\luke\lua\planar_turning_modal.lua" "destRes" = "m_gtlstn" END
+	//
+	WITH_SCOPE BEGIN
+		OUTER_SET "feedback_strref" = RESOLVE_STR_REF (@1)
+		LAF "APPEND_LUA_FUNCTION" STR_VAR "description" = "Functions to be invoked via op402" "sourceFileSpec" = "cdtweaks\luke\lua\planar_turning.lua" "destRes" = "m_gt#402" END
+	END
+	//
+	ACTION_IF !(FILE_EXISTS_IN_GAME "m_gttbls.lua") BEGIN
+		COPY "cdtweaks\luke\lua\m_gttbls.lua" "override"
+	END
+END

--- a/cdtweaks/luke/lua/planar_turning.lua
+++ b/cdtweaks/luke/lua/planar_turning.lua
@@ -1,0 +1,124 @@
+-- cdtweaks, Planar Turning class feat for Paladins and Clerics --
+
+function GTPLNTRN(CGameEffect, CGameSprite)
+	local parentResRef = CGameEffect.m_sourceRes:get()
+	--
+	local sourceSprite = EEex_GameObject_Get(CGameEffect.m_sourceId)
+	local isEvil = EEex_Trigger_ParseConditionalString("Alignment(Myself,MASK_EVIL)")
+	local sourceTurnUndeadLevel = sourceSprite.m_derivedStats.m_nTurnUndeadLevel + sourceSprite.m_bonusStats.m_nTurnUndeadLevel
+	--
+	local targetRaceStr = GT_Resource_IDSToSymbol["race"][CGameSprite.m_typeAI.m_Race]
+	local targetLevel = CGameSprite.m_derivedStats.m_nLevel1 + CGameSprite.m_bonusStats.m_nLevel1
+	--
+	local roll = math.random(0, 3) -- engine: ((int)((rand() & 0x7fff) << 2) >> 0xf) => generates a random number, keeps its lower 15 bits, multiplies by 2^2, divides by 2^15
+	--
+	if targetRaceStr == "DEMONIC" or targetRaceStr == "MEPHIT" or targetRaceStr == "IMP" or targetRaceStr == "ELEMENTAL" or targetRaceStr == "SALAMANDER" or targetRaceStr == "SOLAR" or targetRaceStr == "ANTISOLAR" or targetRaceStr == "DARKPLANATAR" or targetRaceStr == "PLANATAR" or targetRaceStr == "GENIE" then -- if extraplanar ...
+		if sourceTurnUndeadLevel < (targetLevel + roll) + 5 then
+			if sourceTurnUndeadLevel >= (targetLevel + roll) then -- turn
+				CGameSprite:applyEffect({
+					["effectID"] = 174, -- Play sound
+					["durationType"] = 1,
+					["res"] = "ACT_06",
+					["sourceID"] = CGameEffect.m_sourceId,
+					["sourceTarget"] = CGameEffect.m_sourceTarget,
+				})
+				CGameSprite:applyEffect({
+					["effectID"] = 141, -- Lighting effects
+					["durationType"] = 1,
+					["dwFlags"] = 24, -- Effect: Invocation air
+					["sourceID"] = CGameEffect.m_sourceId,
+					["sourceTarget"] = CGameEffect.m_sourceTarget,
+				})
+				CGameSprite:applyEffect({
+					["effectID"] = 321, -- Remove effects by resource
+					["durationType"] = 1,
+					["res"] = parentResRef,
+					["sourceID"] = CGameEffect.m_sourceId,
+					["sourceTarget"] = CGameEffect.m_sourceTarget,
+				})
+				CGameSprite:applyEffect({
+					["effectID"] = 24, -- Panic
+					["dwFlags"] = 1, -- bypass immunity
+					["noSave"] = true, -- redundant...?
+					["duration"] = 60,
+					["m_sourceRes"] = parentResRef,
+					["sourceID"] = CGameEffect.m_sourceId,
+					["sourceTarget"] = CGameEffect.m_sourceTarget,
+				})
+				CGameSprite:applyEffect({
+					["effectID"] = 142, -- Feedback icon
+					["dwFlags"] = 36, -- icon: panic
+					["noSave"] = true,
+					["duration"] = 60,
+					["m_sourceRes"] = parentResRef,
+					["sourceID"] = CGameEffect.m_sourceId,
+					["sourceTarget"] = CGameEffect.m_sourceTarget,
+				})
+				CGameSprite:applyEffect({
+					["effectID"] = 139, -- Display string
+					["durationType"] = 1,
+					["effectAmount"] = %feedback_strref%,
+					["m_sourceRes"] = parentResRef,
+					["sourceID"] = CGameEffect.m_sourceId,
+					["sourceTarget"] = CGameEffect.m_sourceTarget,
+				})
+			end
+		else -- destroy or take control
+			if isEvil:evalConditionalAsAIBase(sourceSprite) then -- take control
+				CGameSprite:applyEffect({
+					["effectID"] = 174, -- Play sound
+					["durationType"] = 1,
+					["res"] = "ACT_06",
+					["sourceID"] = CGameEffect.m_sourceId,
+					["sourceTarget"] = CGameEffect.m_sourceTarget,
+				})
+				CGameSprite:applyEffect({
+					["effectID"] = 141, -- Lighting effects
+					["durationType"] = 1,
+					["dwFlags"] = 24, -- Effect: Invocation air
+					["sourceID"] = CGameEffect.m_sourceId,
+					["sourceTarget"] = CGameEffect.m_sourceTarget,
+				})
+				CGameSprite:applyEffect({
+					["effectID"] = 321, -- Remove effects by resource
+					["durationType"] = 1,
+					["res"] = parentResRef,
+					["sourceID"] = CGameEffect.m_sourceId,
+					["sourceTarget"] = CGameEffect.m_sourceTarget,
+				})
+				CGameSprite:applyEffect({
+					["effectID"] = 241, -- Control creature
+					["dwFlags"] = 4, -- charm type: controlled
+					["duration"] = 60,
+					["m_sourceRes"] = parentResRef,
+					["sourceID"] = CGameEffect.m_sourceId,
+					["sourceTarget"] = CGameEffect.m_sourceTarget,
+				})
+			else -- destroy
+				CGameSprite:applyEffect({
+					["effectID"] = 174, -- Play sound
+					["durationType"] = 1,
+					["res"] = "ACT_06",
+					["sourceID"] = CGameEffect.m_sourceId,
+					["sourceTarget"] = CGameEffect.m_sourceTarget,
+				})
+				CGameSprite:applyEffect({
+					["effectID"] = 141, -- Lighting effects
+					["durationType"] = 1,
+					["dwFlags"] = 24, -- Effect: Invocation air
+					["sourceID"] = CGameEffect.m_sourceId,
+					["sourceTarget"] = CGameEffect.m_sourceTarget,
+				})
+				CGameSprite:applyEffect({
+					["effectID"] = 13, -- Kill creature
+					["durationType"] = 1,
+					["dwFlags"] = 4, -- normal death
+					["sourceID"] = CGameEffect.m_sourceId,
+					["sourceTarget"] = CGameEffect.m_sourceTarget,
+				})
+			end
+		end
+	end
+	--
+	isEvil:free()
+end

--- a/cdtweaks/luke/lua/planar_turning_modal.lua
+++ b/cdtweaks/luke/lua/planar_turning_modal.lua
@@ -1,0 +1,25 @@
+-- cdtweaks, Planar Turning class feat for Paladins and Clerics --
+
+EEex_Opcode_AddListsResolvedListener(function(sprite)
+	-- sanity check
+	if not EEex_GameObject_IsSprite(sprite) then
+		return
+	end
+	-- internal function that applies the actual turning
+	local turnPlanarMode = function()
+		sprite:applyEffect({
+			["effectID"] = 146, -- Cast spell
+			["durationType"] = 1,
+			["dwFlags"] = 1, -- instant / ignore level
+			["res"] = "CDPLNTRN", -- SPL file
+			["sourceID"] = sprite.m_id,
+			["sourceTarget"] = sprite.m_id,
+		})
+	end
+	-- Check if the creature is turning undead
+	local turnUndeadMode = EEex_Sprite_GetModalState(sprite) == 4 and EEex_Sprite_GetModalTimer(sprite) == 0
+	--
+	if turnUndeadMode then
+		turnPlanarMode()
+	end
+end)

--- a/cdtweaks/readme-cdtweaks.html
+++ b/cdtweaks/readme-cdtweaks.html
@@ -1082,6 +1082,13 @@
         </ul>
       </p>
 
+      <p> <strong>Planar Turning class feat for Paladins / Clerics [Luke]</strong><br />
+        <em><abbr title="Enhanced Edition">EEex</abbr></em></p>
+      <p> This component adds the class feat Planar Turning to Paladins and Clerics.<br>
+        This feat allows outsiders (solars, planetars, elementals, imps, mephits, demons, devils, salamanders, genies and the like) to be turned like undead.<br>
+        As a result, when the Turn Undead ability is activated, any extraplanar being in visual range of the priest are turned, fleeing in terror, if the priest's level is high enough. Especially high-level priests destroy these creatures instead. Evil priests gain control of these extraplanar beings instead of destroying them.
+      </p>
+
     </div>
     <div class="ribbon_rectangle_h3">
       <h3> <a id="contents_convenience" name="contents_convenience"></a>Convenience Tweaks and/or Cheats </h3>

--- a/cdtweaks/setup-cdtweaks.tp2
+++ b/cdtweaks/setup-cdtweaks.tp2
@@ -2822,6 +2822,20 @@ REQUIRE_PREDICATE MOD_IS_INSTALLED ~EEex.tp2~ 0 @29
 REQUIRE_PREDICATE FILE_EXISTS ~cdtweaks/languages/%LANGUAGE%/divine_grace_dark_blessing.tra~ @7
 LABEL ~cd_tweaks_divine_grace_dark_blessing~
 
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////
+/////                                                            \\\\\/////
+///// Planar Turning class feat for Paladins / Clerics                \\\\\
+/////                                                            \\\\\/////
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////
+
+BEGIN @277000 DESIGNATED 2770
+GROUP @9
+REQUIRE_PREDICATE MOD_IS_INSTALLED ~EEex.tp2~ 0 @29
+REQUIRE_PREDICATE FILE_EXISTS ~cdtweaks/languages/%LANGUAGE%/planar_turning.tra~ @7
+LABEL ~cd_tweaks_planar_turning~
+
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////                                                  \\\\\


### PR DESCRIPTION
This feat allows **outsiders** (solars, planetars, elementals, imps, mephits, demons, devils, salamanders, genies and the like) to be turned like undead.