### PR TITLE
Circle Kick class feat for Monks

### DIFF
--- a/cdtweaks/languages/english/circle_kick.tra
+++ b/cdtweaks/languages/english/circle_kick.tra
@@ -1,0 +1,1 @@
+@0 = "Circle Kick"

--- a/cdtweaks/languages/english/weidu.tra
+++ b/cdtweaks/languages/english/weidu.tra
@@ -464,6 +464,8 @@ The uninstall messages above are normal and expected.
 
 @271000 = "Divine Grace / Dark Blessing feat for Paladins / Blackguards [Luke]"
 
+@278000 = "Circle Kick class feat for Monks [Luke]"
+
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////                                                  \\\\\

--- a/cdtweaks/languages/italian/circle_kick.tra
+++ b/cdtweaks/languages/italian/circle_kick.tra
@@ -1,0 +1,1 @@
+@0 = "Calcio Rotante"

--- a/cdtweaks/languages/italian/weidu.tra
+++ b/cdtweaks/languages/italian/weidu.tra
@@ -419,6 +419,8 @@ o rimpiazzata da - un'altra facente parte di uno dei mods installati.~
 
 @271000 = "Grazia Divina / Benedizione Oscura per Paladini / Guardie Nere [Luke]"
 
+@278000 = "Aggiungi talento di classe Calcio Rotante per i Monaci [Luke]"
+
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////                                                  \\\\\

--- a/cdtweaks/lib/circle_kick.tph
+++ b/cdtweaks/lib/circle_kick.tph
@@ -1,0 +1,29 @@
+DEFINE_ACTION_FUNCTION "CIRCLE_KICK"
+BEGIN
+	CREATE "eff" "cdcrkick"
+	COPY_EXISTING "cdcrkick.eff" "override"
+		WRITE_LONG 0x10 402 // invoke lua
+		WRITE_SHORT 0x2C 100 // prob1
+		WRITE_ASCII 0x30 "GTCKICK1" #8 // lua function
+	BUT_ONLY
+	//
+	CREATE "spl" "cdcrkick"
+	COPY_EXISTING "cdcrkick.spl" "override"
+		WRITE_LONG NAME1 RESOLVE_STR_REF (@0)
+		WRITE_LONG 0x18 BIT14 // flags: ignore dead/wild magic
+		WRITE_SHORT 0x1C 4 // type: innate
+		WRITE_LONG 0x34 1 // level
+		//
+		LPF "ADD_SPELL_HEADER" INT_VAR "range" = 30 END
+		//
+		LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 402 "target" = 2 STR_VAR "resource" = "GTCKICK2" END // invoke lua
+	BUT_ONLY_IF_IT_CHANGES
+	// Listener: run 'func' each time a sprite has finished evaluating its effects
+	LAF "APPEND_LUA_FUNCTION" STR_VAR "description" = "Listeners" "sourceFileSpec" = "cdtweaks\luke\lua\circle_kick_grant.lua" "destRes" = "m_gtlstn" END
+	//
+	LAF "APPEND_LUA_FUNCTION" STR_VAR "description" = "Functions to be invoked via op402" "sourceFileSpec" = "cdtweaks\luke\lua\circle_kick.lua" "destRes" = "m_gt#402" END
+	//
+	ACTION_IF !(FILE_EXISTS_IN_GAME "m_gttbls.lua") BEGIN
+		COPY "cdtweaks\luke\lua\m_gttbls.lua" "override"
+	END
+END

--- a/cdtweaks/lib/comp_2780.tpa
+++ b/cdtweaks/lib/comp_2780.tpa
@@ -1,0 +1,18 @@
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////
+/////                                                                 /////
+///// Circle Kick class feat for Monks                                \\\\\
+/////                                                                 \\\\\
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////
+
+WITH_SCOPE BEGIN
+  INCLUDE "cdtweaks\luke\misc.tph"
+  INCLUDE "cdtweaks\ardanis\functions.tph"
+  //
+  INCLUDE "cdtweaks\lib\circle_kick.tph"
+  //
+  WITH_TRA "cdtweaks\languages\english\circle_kick.tra" "cdtweaks\languages\%LANGUAGE%\circle_kick.tra" BEGIN
+    LAF "CIRCLE_KICK" END
+  END
+END

--- a/cdtweaks/luke/lua/circle_kick.lua
+++ b/cdtweaks/luke/lua/circle_kick.lua
@@ -1,0 +1,69 @@
+-- cdtweaks, NWN-ish Circle Kick class feat for Monks --
+
+function GTCKICK1(CGameEffect, CGameSprite)
+	local sourceSprite = EEex_GameObject_Get(CGameEffect.m_sourceId)
+	--
+	local sourceSeeInvisible = sourceSprite.m_derivedStats.m_bSeeInvisible + sourceSprite.m_bonusStats.m_bSeeInvisible
+	--
+	local inWeaponRange = EEex_Trigger_ParseConditionalString("InWeaponRange(EEex_LuaObject)")
+	local reallyForceSpell = EEex_Action_ParseResponseString('ReallyForceSpellRES("CDCRKICK",EEex_LuaObject)')
+	-- limit to once per round
+	local getTimer = EEex_Trigger_ParseConditionalString('!GlobalTimerNotExpired("cdtweaksCircleKickTimer","LOCALS")')
+	local setTimer = EEex_Action_ParseResponseString('SetGlobalTimer("cdtweaksCircleKickTimer","LOCALS",6)')
+	--
+	local spriteArray = {}
+	if sourceSprite.m_typeAI.m_EnemyAlly > 200 then -- EVILCUTOFF
+		spriteArray = EEex_Sprite_GetAllOfTypeStringInRange(sourceSprite, "[GOODCUTOFF]", sourceSprite:virtual_GetVisualRange(), nil, nil, nil)
+	elseif sourceSprite.m_typeAI.m_EnemyAlly < 30 then -- GOODCUTOFF
+		spriteArray = EEex_Sprite_GetAllOfTypeStringInRange(sourceSprite, "[EVILCUTOFF]", sourceSprite:virtual_GetVisualRange(), nil, nil, nil)
+	end
+	--
+	for _, itrSprite in ipairs(spriteArray) do
+		if itrSprite.m_id ~= CGameSprite.m_id then -- skip current target
+			EEex_LuaObject = itrSprite -- must be global
+			local spriteGeneralState = itrSprite.m_derivedStats.m_generalState + itrSprite.m_bonusStats.m_generalState
+			--
+			if getTimer:evalConditionalAsAIBase(sourceSprite) and inWeaponRange:evalConditionalAsAIBase(sourceSprite) and EEex_IsBitUnset(spriteGeneralState, 11) then
+				if EEex_IsBitUnset(spriteGeneralState, 0x4) or sourceSeeInvisible > 0 then
+					reallyForceSpell:executeResponseAsAIBaseInstantly(sourceSprite)
+					break
+				end
+			end
+		end
+	end
+	--
+	getTimer:free()
+	setTimer:free()
+	inWeaponRange:free()
+	reallyForceSpell:free()
+end
+
+-- cdtweaks, NWN-ish Circle Kick class feat for Monks --
+
+function GTCKICK2(CGameEffect, CGameSprite)
+	local sourceSprite = EEex_GameObject_Get(CGameEffect.m_sourceId)
+	--
+	local equipment = sourceSprite.m_equipment
+	local selectedWeapon = equipment.m_items:get(equipment.m_selectedWeapon)
+	local itemHeader = selectedWeapon.pRes.pHeader -- Item_Header_st
+	--
+	local itemAbility = EEex_Resource_GetItemAbility(itemHeader, equipment.m_selectedWeaponAbility) -- Item_ability_st
+	--
+	local randomValue = math.random(0, 1)
+	local damageType = {16, 0, 256, 128, 2048, 16 * randomValue, randomValue == 0 and 16 or 256, 256 * randomValue} -- piercing, crushing, slashing, missile, non-lethal, piercing/crushing, piercing/slashing, slashing/crushing
+	if damageType[itemAbility.damageType] then
+		EEex_GameObject_ApplyEffect(CGameSprite,
+		{
+			["effectID"] = 12, -- Damage
+			["dwFlags"] = damageType[itemAbility.damageType] * 0x10000, -- Normal
+			["durationType"] = 1,
+			["numDice"] = itemAbility.damageDiceCount,
+			["diceSize"] = itemAbility.damageDice,
+			["effectAmount"] = itemAbility.damageDiceBonus,
+			["m_sourceRes"] = CGameEffect.m_sourceRes:get(),
+			["m_sourceType"] = CGameEffect.m_sourceType,
+			["sourceID"] = CGameEffect.m_sourceId,
+			["sourceTarget"] = CGameEffect.m_sourceTarget,
+		})
+	end
+end

--- a/cdtweaks/luke/lua/circle_kick_grant.lua
+++ b/cdtweaks/luke/lua/circle_kick_grant.lua
@@ -1,0 +1,55 @@
+-- cdtweaks: NWN-ish Circle Kick class feat for Monks --
+
+EEex_Opcode_AddListsResolvedListener(function(sprite)
+	-- Sanity check
+	if not EEex_GameObject_IsSprite(sprite) then
+		return
+	end
+	-- internal function that applies the actual feat
+	local apply = function()
+		-- Mark the creature as 'feat applied'
+		sprite:setLocalInt("cdtweaksCircleKick", 1)
+		--
+		sprite:applyEffect({
+			["effectID"] = 321, -- Remove effects by resource
+			["durationType"] = 1,
+			["res"] = "CDCRKICK",
+			["sourceID"] = sprite.m_id,
+			["sourceTarget"] = sprite.m_id,
+		})
+		sprite:applyEffect({
+			["effectID"] = 248, -- Melee hit effect
+			["dwFlags"] = 4, -- fist-only
+			["durationType"] = 9,
+			["res"] = "CDCRKICK", -- EFF file
+			["m_sourceRes"] = "CDCRKICK",
+			["sourceID"] = sprite.m_id,
+			["sourceTarget"] = sprite.m_id,
+		})
+	end
+	-- Check creature's class / flags
+	local spriteClassStr = GT_Resource_IDSToSymbol["class"][sprite.m_typeAI.m_Class]
+	--
+	local applyAbility = spriteClassStr == "MONK"
+	--
+	if sprite:getLocalInt("cdtweaksCircleKick") == 0 then
+		if applyAbility then
+			apply()
+		end
+	else
+		if applyAbility then
+			-- do nothing
+		else
+			-- Mark the creature as 'feat removed'
+			sprite:setLocalInt("cdtweaksCircleKick", 0)
+			--
+			sprite:applyEffect({
+				["effectID"] = 321, -- Remove effects by resource
+				["durationType"] = 1,
+				["res"] = "CDCRKICK",
+				["sourceID"] = sprite.m_id,
+				["sourceTarget"] = sprite.m_id,
+			})
+		end
+	end
+end)

--- a/cdtweaks/readme-cdtweaks.html
+++ b/cdtweaks/readme-cdtweaks.html
@@ -1045,6 +1045,17 @@
           </ul>
         </li>
       </ul>
+
+      <p> <strong>Circle Kick class feat for Monks [Luke]</strong><br />
+        <em><abbr title="Enhanced Edition">EEex</abbr></em></p>
+      <p> This component aims at implementing the NWN feat Circle Kick.<br>
+        As a result, after installing it, if the character succeeds in hitting an opponent with an unarmed attack, that character gets an additional free attack against another, nearby enemy. There is a maximum of one free attack per round.<br>
+        Notes:
+        <ul>
+          <li>Use: automatic, but only available to Monks.</li>
+        </ul>
+      </p>
+
     </div>
     <div class="ribbon_rectangle_h3">
       <h3> <a id="contents_convenience" name="contents_convenience"></a>Convenience Tweaks and/or Cheats </h3>

--- a/cdtweaks/setup-cdtweaks.tp2
+++ b/cdtweaks/setup-cdtweaks.tp2
@@ -2822,6 +2822,20 @@ REQUIRE_PREDICATE MOD_IS_INSTALLED ~EEex.tp2~ 0 @29
 REQUIRE_PREDICATE FILE_EXISTS ~cdtweaks/languages/%LANGUAGE%/divine_grace_dark_blessing.tra~ @7
 LABEL ~cd_tweaks_divine_grace_dark_blessing~
 
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////
+/////                                                            \\\\\/////
+///// Circle Kick class feat for Monks                                \\\\\
+/////                                                            \\\\\/////
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////
+
+BEGIN @278000 DESIGNATED 2780
+GROUP @9
+REQUIRE_PREDICATE MOD_IS_INSTALLED ~EEex.tp2~ 0 @29
+REQUIRE_PREDICATE FILE_EXISTS ~cdtweaks/languages/%LANGUAGE%/circle_kick.tra~ @7
+LABEL ~cd_tweaks_circle_kick~
+
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////                                                  \\\\\


### PR DESCRIPTION
If the character succeeds in hitting an opponent with an **unarmed attack**, that character gets an additional free attack against another, nearby enemy. There is a maximum of _one_ free attack per round.