### PR TITLE
Metamagic class feat for Spellcasters

### DIFF
--- a/cdtweaks/languages/english/metamagic.tra
+++ b/cdtweaks/languages/english/metamagic.tra
@@ -1,0 +1,26 @@
+@0 = "Able to Quicken Spells"
+@1 = "Quicken Spell"
+@2 = "Quicken Spell
+
+Quickened spells can be cast instantaneously, making them invulnerable to interruption."
+
+@3 = "Able to Empower Spells"
+@4 = "Empower Spell"
+@5 = "Empower Spell
+
+All variable, numeric effects of an empowered spell are increased by 50% (Empowerment does not increase spell duration)."
+
+@6 = "Able to Extend Spells"
+@7 = "Extend Spell"
+@8 = "Extend Spell
+
+Extended spells have their duration doubled, lasting twice as long as normal."
+
+@9 = "Able to Maximize Spells"
+@10 = "Maximize Spell"
+@11 = "Maximize Spell
+
+Maximized spells apply all variable numeric effects — including damage, number of targets, and so on — at their maximum values."
+
+@12 = "Metamagic: Spell cancelled : the targeted point is out of range"
+@13 = "Metamagic: The selected spell cannot be modified"

--- a/cdtweaks/languages/english/weidu.tra
+++ b/cdtweaks/languages/english/weidu.tra
@@ -464,6 +464,8 @@ The uninstall messages above are normal and expected.
 
 @271000 = "Divine Grace / Dark Blessing feat for Paladins / Blackguards [Luke]"
 
+@279000 = "Metamagic class feat for Spellcasters [Luke]"
+
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////                                                  \\\\\

--- a/cdtweaks/languages/italian/metamagic.tra
+++ b/cdtweaks/languages/italian/metamagic.tra
@@ -1,0 +1,26 @@
+@0 = "Incantesimo Rapido"
+@1 = "Incantesimo Rapido"
+@2 = "Incantesimo Rapido
+
+Gli incantesimi rapidi possono essere lanciati istantaneamente, senza rischiare che vengano interrotti."
+
+@3 = "Incantesimo Potenziato"
+@4 = "Incantesimo Potenziato"
+@5 = "Incantesimo Potenziato
+
+Tutti gli effetti numerici di un incantesimo potenziato vengono aumentati del 50% (la durata dell'incantesimo non viene modificata)."
+
+@6 = "Incantesimo Esteso"
+@7 = "Incantesimo Esteso"
+@8 = "Incantesimo Esteso
+
+Gli incantesimi estesi hanno una durata doppia rispetto al normale."
+
+@9 = "Incantesimo Massimizzato"
+@10 = "Incantesimo Massimizzato"
+@11 = "Incantesimo Massimizzato
+
+Gli incantesimi massimizzati applicano i loro effetti numerici — danno, numero di bersagli, eccetera — al massimo del loro valore."
+
+@12 = "Metamagia: Incantesimo annullato : il punto selezionato è fuori portata"
+@13 = "Metamagia: L'incantesimo selezionato non può essere modificato"

--- a/cdtweaks/languages/italian/weidu.tra
+++ b/cdtweaks/languages/italian/weidu.tra
@@ -419,6 +419,8 @@ o rimpiazzata da - un'altra facente parte di uno dei mods installati.~
 
 @271000 = "Grazia Divina / Benedizione Oscura per Paladini / Guardie Nere [Luke]"
 
+@279000 = "Aggiungi talento di classe Metamagia per gli Incantatori [Luke]"
+
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////                                                  \\\\\

--- a/cdtweaks/lib/metamagic.tph
+++ b/cdtweaks/lib/metamagic.tph
@@ -1,0 +1,54 @@
+DEFINE_ACTION_FUNCTION "METAMAGIC"
+BEGIN
+	LAF "ADD_EXTENDED_STAT" INT_VAR "max" = 4 STR_VAR "identifier" = "CDTWEAKS_METAMAGIC" END
+	//
+	WITH_SCOPE BEGIN
+		ACTION_DEFINE_ASSOCIATIVE_ARRAY "cdtweaks_metamagic" BEGIN
+			// bam file / spl resref, bam file (icon), tra ref (icon), tra ref (name), tra_ref (desc) => stat value
+			"cdmtmqck", "cdmtmgc1", 0, 1, 2 => 1
+			"cdmtmemp", "cdmtmgc2", 3, 4, 5 => 2
+			"cdmtmext", "cdmtmgc3", 6, 7, 8 => 3
+			"cdmtmmax", "cdmtmgc4", 9, 10, 11 => 4
+		END
+		//
+		ACTION_PHP_EACH "cdtweaks_metamagic" AS "key" => "value" BEGIN
+			COPY "cdtweaks\luke\bam\metamagic\%key%.bam" "override" "cdtweaks\luke\bam\metamagic\%key_1%.bam" "override"
+			LAF "ADD_STATDESC_ENTRY" INT_VAR "description" = RESOLVE_STR_REF ((AT "%key_2%")) STR_VAR "bam_file" = "%key_1%" RET "index" END
+			//
+			CREATE "spl" "%key%"
+			COPY_EXISTING "%key%.spl" "override"
+				/* Header */
+				WRITE_LONG NAME1 RESOLVE_STR_REF ((AT "%key_3%"))
+				WRITE_LONG UNIDENTIFIED_DESC RESOLVE_STR_REF ((AT "%key_4%"))
+				WRITE_ASCII 0x10 "CAS_M02" #8 // casting sound
+				WRITE_SHORT 0x1C 4 // innate
+				WRITE_LONG 0x34 1 // level
+				WRITE_ASCII 0x3A "%key%" #8 // icon
+				WRITE_SHORT 0x22 34 // casting animation: swirl white
+				/* Extended Header */
+				LPF "ADD_SPELL_HEADER" INT_VAR "target" = 7 "range" = 30 STR_VAR "icon" = "%key%" END
+				/* Feature Block(s) */
+				LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 321 "timing" = 1 "target" = 1 STR_VAR "resource" = "%DEST_RES%" END
+				/*PATCH_FOR_EACH "res" IN "cdmtmqck" "cdmtmemp" "cdmtmext" "cdmtmmax" BEGIN
+					PATCH_IF ("%res%" STRING_COMPARE_CASE "%DEST_RES%") BEGIN
+						LPF "CLONE_EFFECT" INT_VAR "match_opcode" = 321 "multi_match" = 1 STR_VAR "resource" = "%res%" "insert" = "below" END
+					END
+				END*/
+				LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 401 "timing" = 1 "target" = 1 "parameter2" = 1 "parameter1" = "%value%" "special" = IDS_OF_SYMBOL ("stats" "CDTWEAKS_METAMAGIC") END // Set CDTWEAKS_METAMAGIC to "%value%"
+				LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 142 "timing" = 1 "target" = 1 "parameter2" = "%index%" END // portrait icon
+				// castable at will \\
+				LPF "ADD_SPELL_CFEFFECT" INT_VAR "insert_point" = "-1" "opcode" = 172 "target" = 1 "timing" = 1 STR_VAR "resource" = "%DEST_RES%" END
+				LPF "ADD_SPELL_CFEFFECT" INT_VAR "insert_point" = "-1" "opcode" = 171 "target" = 1 "timing" = 1 STR_VAR "resource" = "%DEST_RES%" END
+			BUT_ONLY
+		END
+	END
+	// Listeners
+	LAF "APPEND_LUA_FUNCTION" STR_VAR "description" = "Listeners" "sourceFileSpec" = "cdtweaks\luke\lua\metamagic\gain.lua" "destRes" = "m_gtlstn" END // run 'func' each time a sprite has finished evaluating its effects
+	WITH_SCOPE BEGIN
+		OUTER_SET "strref_OutOfRange" = RESOLVE_STR_REF (@12)
+		OUTER_SET "strref_CannotBeModified" = RESOLVE_STR_REF (@13)
+		LAF "APPEND_LUA_FUNCTION" STR_VAR "description" = "Listeners" "sourceFileSpec" = "cdtweaks\luke\lua\metamagic\usage.lua" "destRes" = "m_gtlstn" END // cancel "metamagic" mode if the creature is not casting a wizard/priest spell || the given spell cannot be modified
+	END
+	//
+	LAF "APPEND_LUA_FUNCTION" STR_VAR "description" = "Functions to be invoked via op408" "sourceFileSpec" = "cdtweaks\luke\lua\metamagic\projectile_mutator.lua" "destRes" = "m_gt#408" END
+END

--- a/cdtweaks/luke/lua/metamagic/gain.lua
+++ b/cdtweaks/luke/lua/metamagic/gain.lua
@@ -1,0 +1,90 @@
+-- cdtweaks: NWN-ish Metamagic feat for spellcasters --
+
+EEex_Opcode_AddListsResolvedListener(function(sprite)
+	-- internal function that grants the actual feat
+	local gain = function()
+		-- Mark the creature as 'feat granted'
+		sprite:setLocalInt("cdtweaksMetamagic", 1)
+		--
+		local res = {"CDMTMQCK", "CDMTMEMP", "CDMTMMAX", "CDMTMEXT"}
+		for _, v in ipairs(res) do
+			sprite:applyEffect({
+				["effectID"] = 172, -- Remove spell
+				["durationType"] = 1,
+				["res"] = v,
+				["sourceID"] = sprite.m_id,
+				["sourceTarget"] = sprite.m_id,
+			})
+			sprite:applyEffect({
+				["effectID"] = 171, -- Give spell
+				["durationType"] = 1,
+				["res"] = v,
+				["sourceID"] = sprite.m_id,
+				["sourceTarget"] = sprite.m_id,
+			})
+		end
+		--
+		sprite:applyEffect({
+			["effectID"] = 321, -- Remove effects by resource
+			["durationType"] = 1,
+			["res"] = "CDMMAGIC",
+			["sourceID"] = sprite.m_id,
+			["sourceTarget"] = sprite.m_id,
+		})
+		sprite:applyEffect({
+			["effectID"] = 408, -- Projectile mutator
+			["durationType"] = 9,
+			["res"] = "GTMMAGIC", -- lua function
+			["m_sourceRes"] = "CDMMAGIC",
+			["sourceID"] = sprite.m_id,
+			["sourceTarget"] = sprite.m_id,
+		})
+	end
+	-- Check creature's class / flags
+	local spriteClassStr = GT_Resource_IDSToSymbol["class"][sprite.m_typeAI.m_Class]
+	--
+	local spriteFlags = sprite.m_baseStats.m_flags
+	-- since ``EEex_Opcode_AddListsResolvedListener`` is running after the effect lists have been evaluated, ``m_bonusStats`` has already been added to ``m_derivedStats`` by the engine
+	local spriteLevel1 = sprite.m_derivedStats.m_nLevel1
+	local spriteLevel2 = sprite.m_derivedStats.m_nLevel2
+	-- Check if spellcaster class -- single/multi/(complete)dual
+	local gainAbility = spriteClassStr == "MAGE" or spriteClassStr == "CLERIC" or spriteClassStr == "DRUID" or spriteClassStr == "FIGHTER_MAGE_THIEF" or spriteClassStr == "FIGHTER_MAGE_CLERIC" or spriteClassStr == "CLERIC_MAGE"
+		or (spriteClassStr == "FIGHTER_MAGE" and (EEex_IsBitUnset(spriteFlags, 0x4) or spriteLevel1 > spriteLevel2))
+		or (spriteClassStr == "FIGHTER_CLERIC" and (EEex_IsBitUnset(spriteFlags, 0x5) or spriteLevel1 > spriteLevel2))
+		or (spriteClassStr == "MAGE_THIEF" and (EEex_IsBitUnset(spriteFlags, 0x4) or spriteLevel2 > spriteLevel1))
+		or (spriteClassStr == "CLERIC_THIEF" and (EEex_IsBitUnset(spriteFlags, 0x5) or spriteLevel2 > spriteLevel1))
+		or (spriteClassStr == "FIGHTER_DRUID" and (EEex_IsBitUnset(spriteFlags, 0x7) or spriteLevel1 > spriteLevel2))
+		or (spriteClassStr == "CLERIC_RANGER" and (EEex_IsBitUnset(spriteFlags, 0x5) or spriteLevel2 > spriteLevel1))
+	--
+	if sprite:getLocalInt("cdtweaksMetamagic") == 0 then
+		if gainAbility then
+			gain()
+		end
+	else
+		if gainAbility then
+			-- do nothing
+		else
+			-- Mark the creature as 'feat removed'
+			sprite:setLocalInt("cdtweaksMetamagic", 0)
+			--
+			local res = {"CDMTMQCK", "CDMTMEMP", "CDMTMMAX", "CDMTMEXT"}
+			for _, v in ipairs(res) do
+				sprite:applyEffect({
+					["effectID"] = 172, -- Remove spell
+					["durationType"] = 1,
+					["res"] = v,
+					["sourceID"] = sprite.m_id,
+					["sourceTarget"] = sprite.m_id,
+				})
+			end
+			--
+			sprite:applyEffect({
+				["effectID"] = 321, -- Remove effects by resource
+				["durationType"] = 1,
+				["res"] = "CDMMAGIC",
+				["sourceID"] = sprite.m_id,
+				["sourceTarget"] = sprite.m_id,
+			})
+		end
+	end
+end)

--- a/cdtweaks/luke/lua/metamagic/projectile_mutator.lua
+++ b/cdtweaks/luke/lua/metamagic/projectile_mutator.lua
@@ -1,0 +1,279 @@
+-- cdtweaks: NWN-ish metamagic feat for spellcasters (alter effects delivered by the spell accordingly) --
+
+GTMMAGIC = {
+	["typeMutator"] = function(context) -- this kicks in as soon as the projectile is created
+		local CGameSprite = context["originatingSprite"]
+		local metamagicArray = {"CDMTMQCK", "CDMTMEMP", "CDMTMEXT", "CDMTMMAX"}
+		local metamagicType = EEex_Sprite_GetStat(CGameSprite, GT_Resource_SymbolToIDS["stats"]["CDTWEAKS_METAMAGIC"])
+		--
+		if metamagicType > 0 then
+			sprite:applyEffect({
+				["effectID"] = 321, -- Remove effects by resource
+				["durationType"] = 1,
+				["res"] = metamagicArray[metamagicType],
+				["sourceID"] = sprite.m_id,
+				["sourceTarget"] = sprite.m_id,
+			})
+		end
+	end,
+
+	["projectileMutator"] = function(context)
+		local projectile = context["projectile"] -- CProjectile
+		local CGameSprite = context["originatingSprite"]
+		local metamagicType = EEex_Sprite_GetStat(CGameSprite, GT_Resource_SymbolToIDS["stats"]["CDTWEAKS_METAMAGIC"])
+		--
+		if EEex_Projectile_IsOfType(projectile, EEex_Projectile_Type["CProjectileArea"]) and metamagicType == 3 then
+			projectile.m_nRepetitionCount = projectile.m_nRepetitionCount * 2
+		end
+	end,
+
+	["effectMutator"] = function(context)
+		local CGameEffect = context["effect"]
+		local CGameSprite = context["originatingSprite"]
+		local metamagicType = EEex_Sprite_GetStat(CGameSprite, GT_Resource_SymbolToIDS["stats"]["CDTWEAKS_METAMAGIC"])
+		local projectile = context["projectile"] -- CProjectile
+		--
+		if metamagicType == 2 then -- EMPOWER
+			if CGameEffect.m_effectId == 0xC -- Damage (12)
+				or CGameEffect.m_effectId == 0x11 -- Current HP bonus (17)
+				or CGameEffect.m_effectId == 0x12 -- Max HP bonus (18)
+				or CGameEffect.m_effectId == 0x7F -- Summon Monsters (127)
+				or CGameEffect.m_effectId == 0x14B -- Summon Monsters 2 (331)
+			then
+				if CGameEffect.m_effectAmount > 1 then
+					CGameEffect.m_effectAmount = CGameEffect.m_effectAmount + math.floor(CGameEffect.m_effectAmount / 2)
+				elseif CGameEffect.m_diceSize > 1 then
+					CGameEffect.m_diceSize = CGameEffect.m_diceSize + math.floor(CGameEffect.m_diceSize / 2)
+				end
+			end
+			--
+			if CGameEffect.m_effectId == 0x1 -- APR bonus (1)
+				or CGameEffect.m_effectId == 0x6 -- CHR bonus (6)
+				or CGameEffect.m_effectId == 0xA -- CON bonus (10)
+				or CGameEffect.m_effectId == 0xF -- DEX bonus (15)
+				or CGameEffect.m_effectId == 0x13 -- INT bonus (19)
+				or CGameEffect.m_effectId == 0x15 -- Lore bonus (21)
+				or CGameEffect.m_effectId == 0x16 -- Luck bonus (22)
+				or CGameEffect.m_effectId == 0x17 -- Morale bonus (23)
+				or CGameEffect.m_effectId == 0x1B -- Acid resistance bonus (27)
+				or CGameEffect.m_effectId == 0x1C -- Cold resistance bonus (28)
+				or CGameEffect.m_effectId == 0x1D -- Electricity resistance bonus (29)
+				or CGameEffect.m_effectId == 0x1E -- Fire resistance bonus (30)
+				or CGameEffect.m_effectId == 0x1F -- Magic damage resistance bonus (31)
+				or CGameEffect.m_effectId == 0x2C -- Strength bonus (44)
+				or CGameEffect.m_effectId == 0x31 -- Wisdom bonus (49)
+				or CGameEffect.m_effectId == 0x36 -- Base THAC0 bonus (54)
+				or CGameEffect.m_effectId == 0x3B -- Move silently bonus (59)
+				or CGameEffect.m_effectId == 0x49 -- Attack damage bonus (73)
+				or CGameEffect.m_effectId == 0x54 -- Magical fire resistance bonus (84)
+				or CGameEffect.m_effectId == 0x55 -- Magical cold resistance bonus (85)
+				or CGameEffect.m_effectId == 0x56 -- Slashing resistance bonus (86)
+				or CGameEffect.m_effectId == 0x57 -- Crushing resistance bonus (87)
+				or CGameEffect.m_effectId == 0x58 -- Piercing resistance bonus (88)
+				or CGameEffect.m_effectId == 0x59 -- Missile resistance bonus (89)
+				or CGameEffect.m_effectId == 0x5A -- Open locks bonus (90)
+				or CGameEffect.m_effectId == 0x5B -- Find traps bonus (91)
+				or CGameEffect.m_effectId == 0x5C -- Pick pockets bonus (92)
+				or CGameEffect.m_effectId == 0x5D -- Fatigue bonus (93)
+				or CGameEffect.m_effectId == 0x5E -- Intoxication bonus (94)
+				or CGameEffect.m_effectId == 0x5F -- Tracking bonus (95)
+				or CGameEffect.m_effectId == 0x60 -- Change level (96)
+				or CGameEffect.m_effectId == 0x61 -- Exceptional strength bonus (97)
+				or CGameEffect.m_effectId == 0x68 -- XP bonus (104)
+				or CGameEffect.m_effectId == 0x69 -- Remove gold (105)
+				or CGameEffect.m_effectId == 0x6A -- Morale break (106)
+				or CGameEffect.m_effectId == 0x6C -- Reputation bonus (108)
+				or CGameEffect.m_effectId == 0xA7 -- Missile THAC0 bonus (167)
+				or CGameEffect.m_effectId == 0x107 -- Backstab bonus (263)
+				or CGameEffect.m_effectId == 0x113 -- Hide in shadows bonus (275)
+				or CGameEffect.m_effectId == 0x114 -- Detect illusion bonus (276)
+				or CGameEffect.m_effectId == 0x115 -- Set traps bonus (277)
+				or CGameEffect.m_effectId == 0x116 -- THAC0 bonus (278)
+				or CGameEffect.m_effectId == 0x119 -- Wild surge bonus (281)
+				or CGameEffect.m_effectId == 0x11C -- Melee THAC0 bonus (284)
+				or CGameEffect.m_effectId == 0x11D -- Melee weapon damage bonus (285)
+				or CGameEffect.m_effectId == 0x11E -- Missile weapon damage bonus (286)
+				or CGameEffect.m_effectId == 0x120 -- Fist THAC0 bonus (288)
+				or CGameEffect.m_effectId == 0x121 -- Fist damage bonus (289)
+				or CGameEffect.m_effectId == 0x131 -- Off-hand THAC0 bonus (305)
+				or CGameEffect.m_effectId == 0x132 -- Main hand THAC0 bonus (306)
+				or CGameEffect.m_effectId == 0x143 -- Turn undead level (323)
+				or CGameEffect.m_effectId == 0x15A -- Save vs. school bonus (346)
+			then
+				if CGameEffect.m_dWFlags == 0 then -- mode: increment
+					CGameEffect.m_effectAmount = CGameEffect.m_effectAmount + math.floor(CGameEffect.m_effectAmount / 2)
+				elseif CGameEffect.m_dWFlags == 2 then -- mode: set %
+					if CGameEffect.m_effectAmount ~= 100 then
+						if CGameEffect.m_effectAmount > 100 then
+							CGameEffect.m_effectAmount = CGameEffect.m_effectAmount + math.floor(CGameEffect.m_effectAmount / 2)
+						else
+							CGameEffect.m_effectAmount = CGameEffect.m_effectAmount - math.floor(CGameEffect.m_effectAmount / 2)
+						end
+					end
+				end
+			end
+			--
+			if CGameEffect.m_effectId == 0x2A -- Bonus wizard spells (42)
+				or CGameEffect.m_effectId == 0x3C -- Casting failure (60)
+				or CGameEffect.m_effectId == 0x3E -- Bonus priest spells (62)
+				or CGameEffect.m_effectId == 0x6F -- Create weapon (111)
+				or CGameEffect.m_effectId == 0x7A -- Create inventory item (122)
+				or CGameEffect.m_effectId == 0x7F -- Summon Monsters (127)
+				or CGameEffect.m_effectId == 0x81 -- Aid (non-cumulative) (129)
+				or CGameEffect.m_effectId == 0x82 -- Bless (non-cumulative) (130)
+				or CGameEffect.m_effectId == 0x83 -- Chant (non-cumulative) (131)
+				or CGameEffect.m_effectId == 0x84 -- Draw upon holy might (non-cumulative) (132)
+				or CGameEffect.m_effectId == 0x85 -- Luck (non-cumulative) (133)
+				or CGameEffect.m_effectId == 0x89 -- Bad chant (non-cumulative) (137)
+				or CGameEffect.m_effectId == 0x9F -- Mirror image effect (159)
+				or CGameEffect.m_effectId == 0xA6 -- Magic resistance bonus (166)
+				or CGameEffect.m_effectId == 0xAD -- Poison resistance bonus (173)
+				or CGameEffect.m_effectId == 0xBE -- Increase attack speed factor (190)
+				or CGameEffect.m_effectId == 0xBF -- Casting level bonus (191)
+				or CGameEffect.m_effectId == 0xC8 -- Spell turning (200)
+				or CGameEffect.m_effectId == 0xC9 -- Spell deflection (201)
+				or CGameEffect.m_effectId == 0xD8 -- Level drain (216)
+				or CGameEffect.m_effectId == 0xDC -- Remove spell school protections (220)
+				or CGameEffect.m_effectId == 0xDD -- Remove spell type protections (221)
+				or CGameEffect.m_effectId == 0xDE -- Teleport field (222)
+				or CGameEffect.m_effectId == 0xDF -- Spell school deflection (223)
+				or CGameEffect.m_effectId == 0xE2 -- Spell type deflection (226)
+				or CGameEffect.m_effectId == 0xE3 -- Spell school turning (227)
+				or CGameEffect.m_effectId == 0xE4 -- Spell type turning (228)
+				or CGameEffect.m_effectId == 0xE5 -- Remove protection by school (229)
+				or CGameEffect.m_effectId == 0xE6 -- Remove protection by type (230)
+				or CGameEffect.m_effectId == 0xEA -- Create contingency (234)
+				or CGameEffect.m_effectId == 0xEB -- Wing buffet (235)
+				or CGameEffect.m_effectId == 0xF3 -- Drain item charges (243)
+				or CGameEffect.m_effectId == 0xF4 -- Drain wizard spells (244)
+				or CGameEffect.m_effectId == 0xFA -- Maximum damage each hit (250)
+				or CGameEffect.m_effectId == 0xFF -- Create item (days) (255)
+				or CGameEffect.m_effectId == 0x101 -- Create spell sequencer (257)
+				or CGameEffect.m_effectId == 0x103 -- Spell trap (259)
+				or CGameEffect.m_effectId == 0x106 -- Visual range bonus (262)
+				or CGameEffect.m_effectId == 0x10D -- Shake screen (269)
+				or CGameEffect.m_effectId == 0x12D -- Critical hit bonus (301)
+				or CGameEffect.m_effectId == 0x149 -- Slow poison (329)
+				or CGameEffect.m_effectId == 0x14C -- Attack damage type bonus (332)
+				or CGameEffect.m_effectId == 0x16A -- Critical miss bonus (362)
+			then
+				CGameEffect.m_effectAmount = CGameEffect.m_effectAmount + math.floor(CGameEffect.m_effectAmount / 2)
+			end
+			--
+			if CGameEffect.m_effectId == 0x63 then -- Modify duration (99)
+				if CGameEffect.m_effectAmount ~= 100 then
+					if CGameEffect.m_effectAmount > 100 then
+						CGameEffect.m_effectAmount = CGameEffect.m_effectAmount + math.floor(CGameEffect.m_effectAmount / 2)
+					else
+						CGameEffect.m_effectAmount = CGameEffect.m_effectAmount - math.floor(CGameEffect.m_effectAmount / 2)
+					end
+				end
+			end
+			--
+			if CGameEffect.m_effectId == 0x7E -- Movement rate bonus (126)
+				or CGameEffect.m_effectId == 0xB0 -- Movement rate bonus 2 (176)
+			then
+				if CGameEffect.m_dWFlags == 0 then -- mode: increment
+					CGameEffect.m_effectAmount = CGameEffect.m_effectAmount + math.floor(CGameEffect.m_effectAmount / 2)
+				elseif CGameEffect.m_dWFlags == 2 or CGameEffect.m_dWFlags == 5 then -- mode: set % / set multiplicative %
+					if CGameEffect.m_effectAmount ~= 100 then
+						if CGameEffect.m_effectAmount > 100 then
+							CGameEffect.m_effectAmount = CGameEffect.m_effectAmount + math.floor(CGameEffect.m_effectAmount / 2)
+						else
+							CGameEffect.m_effectAmount = CGameEffect.m_effectAmount - math.floor(CGameEffect.m_effectAmount / 2)
+						end
+					end
+				end
+			end
+			--
+			if CGameEffect.m_effectId == 0x0 then -- AC bonus
+				if EEex_IsBitSet(CGameEffect.m_dWFlags, 0x4) then -- mode: set base AC
+					if CGameEffect.m_effectAmount > 10 then
+						CGameEffect.m_effectAmount = CGameEffect.m_effectAmount + math.floor(CGameEffect.m_effectAmount / 2)
+					else
+						if CGameEffect.m_effectAmount >= 0 then
+							CGameEffect.m_effectAmount = CGameEffect.m_effectAmount - math.floor(CGameEffect.m_effectAmount / 2)
+						else
+							CGameEffect.m_effectAmount = CGameEffect.m_effectAmount + math.floor(CGameEffect.m_effectAmount / 2)
+						end
+					end
+				else
+					CGameEffect.m_effectAmount = CGameEffect.m_effectAmount + math.floor(CGameEffect.m_effectAmount / 2)
+				end
+			end
+			--
+			if CGameEffect.m_effectId == 0x21 -- Save vs. death bonus (33)
+				or CGameEffect.m_effectId == 0x22 -- Save vs. wand bonus (34)
+				or CGameEffect.m_effectId == 0x23 -- Save vs. polymorph bonus (35)
+				or CGameEffect.m_effectId == 0x24 -- Save vs. breath bonus (36)
+				or CGameEffect.m_effectId == 0x25 -- Save vs. spell bonus (37)
+				or CGameEffect.m_effectId == 0x145 -- All saving throws bonus (325)
+			then
+				if CGameEffect.m_dWFlags == 0 or CGameEffect.m_dWFlags == 3 then -- mode: increment / increment instantaneously
+					CGameEffect.m_effectAmount = CGameEffect.m_effectAmount + math.floor(CGameEffect.m_effectAmount / 2)
+				elseif CGameEffect.m_dWFlags == 2 then -- mode: set %
+					if CGameEffect.m_effectAmount ~= 100 then
+						if CGameEffect.m_effectAmount > 100 then
+							CGameEffect.m_effectAmount = CGameEffect.m_effectAmount + math.floor(CGameEffect.m_effectAmount / 2)
+						else
+							CGameEffect.m_effectAmount = CGameEffect.m_effectAmount - math.floor(CGameEffect.m_effectAmount / 2)
+						end
+					end
+				end
+			end
+			--
+			if CGameEffect.m_effectId == 0xDA then -- Stoneskin (218)
+				if CGameEffect.m_dWFlags == 1 then -- use dice
+					if CGameEffect.m_effectAmount > 1 then
+						CGameEffect.m_effectAmount = CGameEffect.m_effectAmount + math.floor(CGameEffect.m_effectAmount / 2)
+					elseif CGameEffect.m_diceSize > 1 then
+						CGameEffect.m_diceSize = CGameEffect.m_diceSize + math.floor(CGameEffect.m_diceSize / 2)
+					end
+				else
+					CGameEffect.m_effectAmount = CGameEffect.m_effectAmount + math.floor(CGameEffect.m_effectAmount / 2)
+				end
+			end
+			--
+			if CGameEffect.m_effectId == 0x14D then -- Static charge (333)
+				CGameEffect.m_dWFlags = CGameEffect.m_dWFlags + math.floor(CGameEffect.m_dWFlags / 2) -- increase spell level by 50%
+			end
+		------------------------------------------------------------------------------
+		elseif metamagicType == 3 then -- EXTEND
+			if not EEex_Projectile_IsOfType(projectile, EEex_Projectile_Type["CProjectileArea"]) then
+				if CGameEffect.m_effectId == 0x14D then -- Static charge (333)
+					CGameEffect.m_effectAmount = CGameEffect.m_effectAmount * 2 -- # hits
+				else
+					if CGameEffect.m_durationType == 0 -- limited (seconds)
+						or CGameEffect.m_durationType == 3 -- delay/limited (seconds)
+						or CGameEffect.m_durationType == 4 -- delay/permanent (seconds)
+						or CGameEffect.m_durationType == 10 -- limited (ticks)
+					then
+						CGameEffect.m_duration = CGameEffect.m_duration * 2
+					end
+				end
+			end
+		---------------------------------------------------------------------------------
+		elseif metamagicType == 4 then -- MAXIMIZE
+			if CGameEffect.m_effectId == 0xC -- Damage
+				or CGameEffect.m_effectId == 0x11 -- Current HP bonus (17)
+				or CGameEffect.m_effectId == 0x12 -- Max HP bonus (18)
+				or CGameEffect.m_effectId == 0x7F -- Summon Monsters (127)
+				or CGameEffect.m_effectId == 0x14B -- Summon Monsters 2 (331)
+			then
+				CGameEffect.m_effectAmount = CGameEffect.m_effectAmount + CGameEffect.m_numDice * CGameEffect.m_diceSize
+				CGameEffect.m_diceSize = 0
+				CGameEffect.m_numDice = 0
+			end
+			if CGameEffect.m_effectId == 0xDA then -- Stoneskin (218)
+				if CGameEffect.m_dWFlags == 1 then -- mode: use dice values
+					CGameEffect.m_effectAmount = CGameEffect.m_effectAmount + CGameEffect.m_numDice * CGameEffect.m_diceSize
+					CGameEffect.m_diceSize = 0
+					CGameEffect.m_numDice = 0
+				end
+			end
+			if CGameEffect.m_effectId == 0x14D then -- Static charge (333)
+				CGameEffect.m_dWFlags = 0xFFFF -- max unsigned value (65535)
+			end
+		end
+	end
+}

--- a/cdtweaks/luke/lua/metamagic/usage.lua
+++ b/cdtweaks/luke/lua/metamagic/usage.lua
@@ -1,0 +1,152 @@
+-- cdtweaks: NWN-ish metamagic feat for spellcasters (cancel metamagic mode if the caster is not casting a wizard / priest spell || the given spell cannot be modified... Make the spell uninterruptible if quickened) --
+
+EEex_Action_AddSpriteStartedActionListener(function(sprite, action)
+	local metamagicType = EEex_Sprite_GetStat(sprite, GT_Resource_SymbolToIDS["stats"]["CDTWEAKS_METAMAGIC"])
+	local metamagicArray = {"CDMTMQCK", "CDMTMEMP", "CDMTMEXT", "CDMTMMAX"}
+	--
+	if sprite:getLocalInt("cdtweaksMetamagic") == 1 then
+		if metamagicType > 0 then
+			if not (action.m_actionID == 31 or action.m_actionID == 95 or action.m_actionID == 476) then -- Spell() / SpellPoint() / EEex_SpellObjectOffset()
+				sprite:applyEffect({
+					["effectID"] = 321, -- Remove effects by resource
+					["durationType"] = 1,
+					["res"] = metamagicArray[metamagicType],
+					["sourceID"] = sprite.m_id,
+					["sourceTarget"] = sprite.m_id,
+				})
+			else
+				local spellResRef = action.m_string1.m_pchData:get()
+				if spellResRef == "" then
+					spellResRef = GT_Utility_DecodeSpell(action.m_specificID)
+				end
+				--
+				local spellHeader = EEex_Resource_Demand(spellResRef, "SPL")
+				local spellType = spellHeader.itemType
+				--
+				local casterLevel = EEex_Sprite_GetCasterLevelForSpell(sprite, spellResRef, true)
+				local spellAbility = EEex_Resource_GetSpellAbilityForLevel(spellHeader, casterLevel)
+				--
+				if not (spellType == 1 or spellType == 2) then
+					sprite:applyEffect({
+						["effectID"] = 321, -- Remove effects by resource
+						["durationType"] = 1,
+						["res"] = metamagicArray[metamagicType],
+						["sourceID"] = sprite.m_id,
+						["sourceTarget"] = sprite.m_id,
+					})
+				else
+					local found = false
+					--
+					if metamagicType == 1 then -- quicken spell
+						-- ``ReallyForceSpell()`` ignores range and LoS, so we need to check them...
+						if action.m_actionID == 95 or action.m_actionID == 476 then -- SpellPoint() / EEex_SpellObjectOffset()
+							local numCreature = EEex_Area_GetAllOfTypeStringInRange(sprite.m_pArea, action.m_dest.x, action.m_dest.y, "[ANYONE]", (spellAbility.range * 16 < sprite:virtual_GetVisualRange()) and spellAbility.range or sprite:virtual_GetVisualRange(), nil, nil, nil)
+							for _, v in ipairs(numCreature) do
+								if v.m_id == sprite.m_id then
+									found = true
+									break
+								end
+							end
+						else -- ``Spell()``
+							local targetSprite = EEex_GameObject_Get(action.m_acteeID.m_Instance)
+							local numCreature = EEex_Area_GetAllOfTypeStringInRange(sprite.m_pArea, targetSprite.m_pos.x, targetSprite.m_pos.y, "[ANYONE]", (spellAbility.range * 16 < sprite:virtual_GetVisualRange()) and spellAbility.range or sprite:virtual_GetVisualRange(), nil, nil, nil)
+							for _, v in ipairs(numCreature) do
+								if v.m_id == sprite.m_id then
+									found = true
+									break
+								end
+							end
+						end
+					else
+						found = true
+					end
+					--
+					if not found then
+						action.m_actionID = 0 -- nuke current action (do not "cancel" the metamagic mode: let the caster try again)
+						sprite:applyEffect({
+							["effectID"] = 139, -- Display string
+							["durationType"] = 1,
+							["effectAmount"] = %strref_OutOfRange%,
+							["sourceID"] = sprite.m_id,
+							["sourceTarget"] = sprite.m_id,
+						})
+					else
+						local spellLevelMemListArray
+						--
+						if spellType == 1 then -- Wizard
+							spellLevelMemListArray = sprite.m_memorizedSpellsMage
+						elseif spellType == 2 then -- Priest
+							spellLevelMemListArray = sprite.m_memorizedSpellsPriest
+						end
+						--
+						local metamagicReq = {4, 2, 1, 3} -- quicken (+4), empower (+2), extend (+1), maximize (+3)
+						local spellLevel = spellHeader.spellLevel
+						local found = false
+						--
+						if not (spellType == 1) or (spellLevel + metamagicReq[metamagicType]) <= 9 then -- the "modified" spell must be of level [1-9]
+							if not (spellType == 2) or (spellLevel + metamagicReq[metamagicType]) <= 7 then -- the "modified" spell must be of level [1-7]
+								--
+								local alreadyDecreasedResrefs = {}
+								local memList = spellLevelMemListArray:getReference(spellLevel + metamagicReq[metamagicType] - 1) -- count starts from 0 (that is why ``-1``)
+								--
+								EEex_Utility_IterateCPtrList(memList, function(memInstance)
+									local memInstanceResref = memInstance.m_spellId:get()
+									if not alreadyDecreasedResrefs[memInstanceResref] then
+										local memFlags = memInstance.m_flags
+										if EEex_IsBitSet(memFlags, 0x0) then -- if memorized ...
+											memInstance.m_flags = EEex_UnsetBit(memFlags, 0x0) -- ... then unmemorize
+											found = true
+											alreadyDecreasedResrefs[memInstanceResref] = true
+										end
+									end
+								end)
+							end
+						end
+						--
+						if not found then
+							action.m_actionID = 0 -- nuke current action (do not "cancel" the metamagic mode: let the caster try again)
+							sprite:applyEffect({
+								["effectID"] = 139, -- Display string
+								["durationType"] = 1,
+								["effectAmount"] = %strref_CannotBeModified%,
+								["sourceID"] = sprite.m_id,
+								["sourceTarget"] = sprite.m_id,
+							})
+						else
+							if metamagicType == 1 then -- quicken spell
+								-- Morph ``Spell()`` into ``ReallyForceSpell()`` (so as to achieve immuninty to spell disruption)
+								local reallyForceSpell = nil
+								-- if the aura is not free, delay the action
+								if EEex_Sprite_GetCastTimer(sprite) == -1 then -- aura free
+									if action.m_actionID == 31 then -- Spell()
+										local targetSprite = EEex_GameObject_Get(action.m_acteeID.m_Instance)
+										EEex_LuaObject = targetSprite -- must be global
+										reallyForceSpell = EEex_Action_ParseResponseString(string.format('ReallyForceSpellRES("%s",EEex_LuaObject)', spellResRef))
+									elseif action.m_actionID == 95 or action.m_actionID == 476 then -- SpellPoint() / EEex_SpellObjectOffset()
+										reallyForceSpell = EEex_Action_ParseResponseString(string.format('ReallyForceSpellPointRES("%s",[%d.%d])', spellResRef, action.m_dest.x, action.m_dest.y))
+									end
+								else
+									if action.m_actionID == 31 then -- Spell()
+										local targetSprite = EEex_GameObject_Get(action.m_acteeID.m_Instance)
+										EEex_LuaObject = targetSprite -- must be global
+										reallyForceSpell = EEex_Action_ParseResponseString(string.format('SmallWait(%d) \n ReallyForceSpellRES("%s",EEex_LuaObject)', 99 - EEex_Sprite_GetCastTimer(sprite), spellResRef))
+									elseif action.m_actionID == 95 or action.m_actionID == 476 then -- SpellPoint() / EEex_SpellObjectOffset()
+										reallyForceSpell = EEex_Action_ParseResponseString(string.format('SmallWait(%d) \n ReallyForceSpellPointRES("%s",[%d.%d])', 99 - EEex_Sprite_GetCastTimer(sprite), spellResRef, action.m_dest.x, action.m_dest.y))
+									end
+								end
+								--
+								action.m_actionID = 147 -- RemoveSpell()
+								--
+								reallyForceSpell:queueResponseOnAIBase(sprite)
+								reallyForceSpell:free()
+								-- ``ReallyForceSpell()`` does not set the aura, so we manually set it...
+								sprite.m_castCounter = 0
+								sprite.m_bInCasting = 1
+							end
+						end
+					end
+				end
+			end
+		end
+	end
+end)

--- a/cdtweaks/luke/lua/utility/decode_spell.lua
+++ b/cdtweaks/luke/lua/utility/decode_spell.lua
@@ -1,0 +1,18 @@
+-- Utility: get ``spellResRef`` from ID (borrowed from Bubb) --
+
+function GT_Utility_DecodeSpell(spellIDS)
+	local prefix
+	local spellType = math.floor(spellIDS / 1000)
+	--
+	if spellType == 1 then
+		prefix = "SPPR"
+	elseif spellType == 2 then
+		prefix = "SPWI"
+	elseif spellType == 3 then
+		prefix = "SPIN"
+	elseif spellType == 4 then
+		prefix = "SPCL"
+	end
+	--
+	return prefix .. string.format("%03d", spellIDS % 1000)
+end

--- a/cdtweaks/readme-cdtweaks.html
+++ b/cdtweaks/readme-cdtweaks.html
@@ -1045,6 +1045,68 @@
           </ul>
         </li>
       </ul>
+
+      <p> <strong>Metamagic class feat for Spellcasters [Luke]</strong><br />
+        <em><abbr title="Enhanced Edition">EEex</abbr></em></p>
+      <p> This component adds the NWN-ish class feat Metamagic to spellcasters (all but Bards, Sorcerers, and Shamans). </p>
+      <p>
+        As a spellcaster's knowledge of magic grows, she can learn to cast spells in ways slightly different from the ways in which the spells were originally designed or learned. Preparing and casting a spell in such a way is harder than normal but, thanks to metamagic feats, at least it is possible. Spells modified by a metamagic feat use a spell slot higher than normal.<br>
+        The modifications made by these feats only apply to spells cast directly by the feat user. A spellcaster cannot use a metamagic feat to alter a spell being cast from a wand, scroll, or other device.
+        Metamagic feats cannot be used with all spells.
+        Moreover, a spellcaster cannot apply more than one metamagic at a time to a spell.
+      </p>
+      <p>
+        Metamagic feats change some aspect of spells as they are cast, making them more effective or circumventing some restrictions.
+        <ul>
+          <li>
+            <em>Quicken Spell</em><br>
+            Quickened spells can be cast instantaneously, making them invulnerable to interruption.<br>
+            Quickened spells consume spell slots four levels higher than normal.
+            <ul>
+              <li>If you want to quicken a level <code>1</code> spell, all memorized spells of level <code>5</code> will be decremented by 1.</li>
+              <li>Wizard spells of level <code>6+</code> cannot be quickened.</li>
+              <li>Priest spells of level <code>4+</code> cannot be quickened.</li>
+            </ul>
+          </li>
+
+          <li>
+            <em>Empower Spell</em><br>
+            All variable, numeric effects of an empowered spell are increased by 50%. Empowerment does not increase spell duration.<br>
+            An empowered spell consumes a spell slot two levels higher than normal.
+            <ul>
+              <li>If you want to empower a level <code>1</code> spell, all memorized spells of level <code>3</code> will be decremented by 1.</li>
+              <li>Wizard spells of level <code>8+</code> cannot be empowered.</li>
+              <li>Priest spells of level <code>6+</code> cannot be empowered.</li>
+              <li>As a completely artificial example, an empowered Magic Missile will deal <code>1d6 + 1</code> (instead of <code>1d4 + 1</code> ) points of damage.</li>
+            </ul>
+          </li>
+
+          <li>
+            <em>Extend Spell</em><br>
+            Extended spells have their duration doubled, lasting twice as long as normal. Spells with a duration of instantaneous or permanent are not affected.<br>
+            An extended spell consumes a spell slot one level higher than normal.
+            <ul>
+              <li>If you want to extend a level <code>1</code> spell, all memorized spells of level <code>2</code> will be decremented by 1.</li>
+              <li>Wizard spells of level <code>9</code> cannot be extended.</li>
+              <li>Priest spells of level <code>7</code> cannot be extended.</li>
+              <li>As a completely artificial example, an extended Web will last for <code>2</code> turns (instead of <code>1</code>).</li>
+            </ul>
+          </li>
+
+          <li>
+            <em>Maximize Spell</em><br>
+            Maximized spells apply all variable numeric effects — including damage, number of targets, and so on — at their maximum values.<br>
+            A maximized spell consumes a spell slot three levels higher than normal.
+            <ul>
+              <li>If you want to maximize a level <code>1</code> spell, all memorized spells of level <code>4</code> will be decremented by 1.</li>
+              <li>Wizard spells of level <code>7+</code> cannot be maximized.</li>
+              <li>Priest spells of level <code>5+</code> cannot be maximized.</li>
+              <li>As a completely artificial example, an maximized Magic Missile will deal <code>5</code> (instead of <code>1d4 + 1</code> ) points of damage.</li>
+            </ul>
+          </li>
+        </ul>
+      </p>
+
     </div>
     <div class="ribbon_rectangle_h3">
       <h3> <a id="contents_convenience" name="contents_convenience"></a>Convenience Tweaks and/or Cheats </h3>

--- a/cdtweaks/setup-cdtweaks.tp2
+++ b/cdtweaks/setup-cdtweaks.tp2
@@ -2822,6 +2822,20 @@ REQUIRE_PREDICATE MOD_IS_INSTALLED ~EEex.tp2~ 0 @29
 REQUIRE_PREDICATE FILE_EXISTS ~cdtweaks/languages/%LANGUAGE%/divine_grace_dark_blessing.tra~ @7
 LABEL ~cd_tweaks_divine_grace_dark_blessing~
 
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////
+/////                                                            \\\\\/////
+///// Metamagic class feat for Spellcasters                           \\\\\
+/////                                                            \\\\\/////
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////
+/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////
+
+BEGIN @279000 DESIGNATED 2790
+GROUP @9
+REQUIRE_PREDICATE MOD_IS_INSTALLED ~EEex.tp2~ 0 @29
+REQUIRE_PREDICATE FILE_EXISTS ~cdtweaks/languages/%LANGUAGE%/metamagic.tra~ @7
+LABEL ~cd_tweaks_metamagic~
+
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////                                                  \\\\\


### PR DESCRIPTION
This component adds the NWN-ish class feat Metamagic to spellcasters (all but Bards, Sorcerers, and Shamans).
       
Metamagic feats change some aspect of spells as they are cast, making them more effective or circumventing some restrictions.

- <em>Quicken Spell</em>
Quickened spells can be cast instantaneously, making them invulnerable to interruption.
Quickened spells consume spell slots four levels higher than normal.

  - If you want to quicken a level <code>1</code> spell, all memorized spells of level <code>5</code> will be decremented by 1.
  - Wizard spells of level <code>6+</code> cannot be quickened.
  - Priest spells of level <code>4+</code> cannot be quickened.


- <em>Empower Spell</em>
All variable, numeric effects of an empowered spell are increased by 50%. Empowerment does not increase spell duration.<br>
An empowered spell consumes a spell slot two levels higher than normal.

  - If you want to empower a level <code>1</code> spell, all memorized spells of level <code>3</code> will be decremented by 1.
  - Wizard spells of level <code>8+</code> cannot be empowered.
  - Priest spells of level <code>6+</code> cannot be empowered.
  - As a completely artificial example, an empowered Magic Missile will deal <code>1d6 + 1</code> (instead of <code>1d4 + 1</code> ) points of damage.

- <em>Extend Spell</em>
Extended spells have their duration doubled, lasting twice as long as normal. Spells with a duration of instantaneous or permanent are not affected.
An extended spell consumes a spell slot one level higher than normal.

  - If you want to extend a level <code>1</code> spell, all memorized spells of level <code>2</code> will be decremented by 1.
  - Wizard spells of level <code>9</code> cannot be extended.
  - Priest spells of level <code>7</code> cannot be extended.
  - As a completely artificial example, an extended Web will last for <code>2</code> turns (instead of <code>1</code>).

- <em>Maximize Spell</em><br>
Maximized spells apply all variable numeric effects — including damage, number of targets, and so on — at their maximum values.
A maximized spell consumes a spell slot three levels higher than normal.

  - If you want to maximize a level <code>1</code> spell, all memorized spells of level <code>4</code> will be decremented by 1.
  - Wizard spells of level <code>7+</code> cannot be maximized.
  - Priest spells of level <code>5+</code> cannot be maximized.
  - As a completely artificial example, a maximized Magic Missile will deal <code>5</code> (instead of <code>1d4 + 1</code> ) points of damage.