### PR TITLE
New component: Limit resting mechanic

### DIFF
--- a/cdtweaks/languages/english/limit_resting_mechanic.tra
+++ b/cdtweaks/languages/english/limit_resting_mechanic.tra
@@ -1,0 +1,1 @@
+@0 = "Tweaks Anthology: The Party can rest at most once per day"

--- a/cdtweaks/languages/english/weidu.tra
+++ b/cdtweaks/languages/english/weidu.tra
@@ -461,7 +461,7 @@ The uninstall messages above are normal and expected.
 
 @266000 = "Weapon Finesse feat for Thieves [Luke]"
 
-@267000 = "Dual-Wield feat for Rangers [Luke]"
+@267000 = "Limit Resting Mechanic [Luke (EEex)]"
 
 @268000 = ~"Force" the Archer kit to use bows [Luke]~
 

--- a/cdtweaks/languages/italian/limit_resting_mechanic.tra
+++ b/cdtweaks/languages/italian/limit_resting_mechanic.tra
@@ -1,0 +1,1 @@
+@0 = "Tweaks Anthology: Il Gruppo può riposare al massimo una volta al giorno"

--- a/cdtweaks/languages/italian/weidu.tra
+++ b/cdtweaks/languages/italian/weidu.tra
@@ -414,7 +414,7 @@ o rimpiazzata da - un'altra facente parte di uno dei mods installati.~
 
 @266000 = "Aggiungi talento Arma Preferita per i Ladri [Luke]"
 
-@267000 = "Aggiungi talento Doppia-Presa per i Ranger [Luke]"
+@267000 = "Limita la meccanica del Riposo [Luke (EEex)]"
 
 @269000 = "Armatura vs. Destrezza in stile NWN [Luke]"
 

--- a/cdtweaks/lib/comp_2670.tpa
+++ b/cdtweaks/lib/comp_2670.tpa
@@ -1,15 +1,17 @@
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////                                                            \\\\\
-///// Dual-wield feat for Rangers                                \\\\\
+///// Limit resting mechanic                                     \\\\\
 /////                                                            \\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 
 WITH_SCOPE BEGIN
   INCLUDE "cdtweaks\luke\misc.tph"
-  INCLUDE "cdtweaks\lib\dual_wield.tph"
-  WITH_TRA "cdtweaks\languages\english\dual_wield.tra" "cdtweaks\languages\%LANGUAGE%\dual_wield.tra" BEGIN
-    LAF "DUAL_WIELD" END
+  //
+  INCLUDE "cdtweaks\lib\limit_resting_mechanic.tph"
+  //
+  WITH_TRA "cdtweaks\languages\english\limit_resting_mechanic.tra" "cdtweaks\languages\%LANGUAGE%\limit_resting_mechanic.tra" BEGIN
+    LAF "LIMIT_RESTING_MECHANIC" END
   END
 END

--- a/cdtweaks/lib/limit_resting_mechanic.tph
+++ b/cdtweaks/lib/limit_resting_mechanic.tph
@@ -1,0 +1,6 @@
+DEFINE_ACTION_FUNCTION "LIMIT_RESTING_MECHANIC"
+BEGIN
+	OUTER_SET "feedback_strref" = RESOLVE_STR_REF (@0)
+	//
+	LAF "APPEND_LUA_FUNCTION" STR_VAR "description" = "Misc Tweaks (Rule Changes)" "sourceFileSpec" = "cdtweaks\luke\lua\rule_changes\limit_resting_mechanic.lua" "destRes" = "m_gtrule" END
+END

--- a/cdtweaks/luke/lua/rule_changes/limit_resting_mechanic.lua
+++ b/cdtweaks/luke/lua/rule_changes/limit_resting_mechanic.lua
@@ -1,0 +1,27 @@
+--[[
++------------------------------------------------------------------------------+
+| cdtweaks, Limit resting mechanic (at most once every 24 in-game hours)       |
++------------------------------------------------------------------------------+
+| scripted resting will not be blocked; however, it will still reset the timer |
++------------------------------------------------------------------------------+
+--]]
+
+EEex_Action_AddSpriteStartedActionListener(function(sprite, action)
+	if sprite.m_typeAI.m_EnemyAlly == 2 and action.m_actionID == 96 then -- if [PC] and "Rest()"
+		sprite:applyEffect({
+			["effectID"] = 0x141, -- Remove effects by resource (321)
+			["res"] = "GTRULE01",
+			["sourceID"] = sprite.m_id,
+			["sourceTarget"] = sprite.m_id,
+		})
+		--
+		sprite:applyEffect({
+			["effectID"] = 0x152, -- Disable rest or save (338)
+			["effectAmount"] = %feedback_strref%,
+			["duration"] = 7200,
+			["m_sourceRes"] = "GTRULE01",
+			["sourceID"] = sprite.m_id,
+			["sourceTarget"] = sprite.m_id,
+		})
+	end
+end)

--- a/cdtweaks/readme-cdtweaks.html
+++ b/cdtweaks/readme-cdtweaks.html
@@ -1008,9 +1008,9 @@
       <p> This component aims at implementing 3E Weapon Finesse feat for Thieves.</p>
       <p> As a result, after installing it, every time a Thief is wielding a small blade (f.i. daggers, short swords, wakizashis, etc...) or a club/mace, his/her THAC0 will scale with Dexterity (as per the <code>MISSILE</code> column of <a href="https://gibberlings3.github.io/iesdp/files/2da/2da_bgee/dexmod.htm"><code>dexmod.2da</code></a>) instead of Strength.</p>
       <p> As a completely artificial example, suppose a Thief has 9 Strength and 18 Dexterity. Upon equipping a dagger, he/she will gain a THAC0 bonus of <code>2</code> (instead of <code>0</code>). Note that nothing happens if the bonus from Strength is better (or equal) than the bonus from Dexterity. </p>
-      <p> <strong>Dual-Wield feat for Rangers [Luke]</strong><br />
+      <p> <strong>Limit Resting Mechanic [Luke]</strong><br />
         <em><abbr title="Enhanced Edition">EEex</abbr></em></p>
-      <p> This component simply forces Rangers to wield light armors (or no armor) in order to benefit from Two-Weapon Fighting.</p>
+      <p> This component simply forces the Party to rest at most once per 24 in-game hours (does not prevent scripted resting).</p>
       <p> <strong>NWN-ish Armor vs. Dexterity [Luke]</strong><br />
         <em><abbr title="Enhanced Edition">EEex</abbr></em></p>
       <p> This component simply &quot;forces&quot; characters to wield light armors (or no armor) if they have high Dexterity.

--- a/cdtweaks/setup-cdtweaks.tp2
+++ b/cdtweaks/setup-cdtweaks.tp2
@@ -2825,16 +2825,17 @@ LABEL ~cd_tweaks_weapon_finesse~
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////                                                            \\\\\
-///// Dual-Wield feat for Rangers                                \\\\\
+///// Limit resting mechanic                                     \\\\\
 /////                                                            \\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 
 BEGIN @267000 DESIGNATED 2670
 GROUP @9
+REQUIRE_PREDICATE GAME_IS "bgee bg2ee eet iwdee" @25
 REQUIRE_PREDICATE MOD_IS_INSTALLED ~EEex.tp2~ 0 @29
-REQUIRE_PREDICATE FILE_EXISTS ~cdtweaks/languages/%LANGUAGE%/dual_wield.tra~ @7
-LABEL ~cd_tweaks_dual_wield~
+REQUIRE_PREDICATE FILE_EXISTS ~cdtweaks/languages/%LANGUAGE%/limit_resting_mechanic.tra~ @7
+LABEL ~cd_tweaks_limit_resting_mechanic~
 
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\


### PR DESCRIPTION
This component simply forces the Party to rest at most once per 24 in-game hours (does not prevent scripted resting).