### PR TITLE
New component: Alternate Concentration Check

### DIFF
--- a/cdtweaks/languages/english/concentration.tra
+++ b/cdtweaks/languages/english/concentration.tra
@@ -1,0 +1,7 @@
+@0 = "Concentration (Success)"
+@1 = "Spell Level"
+//
+@2 = "Damage Taken"
+@3 = "Constitution Modification"
+@4 = "Luck"
+@5 = "15"

--- a/cdtweaks/languages/english/weidu.tra
+++ b/cdtweaks/languages/english/weidu.tra
@@ -465,7 +465,11 @@ The uninstall messages above are normal and expected.
 
 @268000 = ~"Force" the Archer kit to use bows [Luke]~
 
-@269000 = "NWN-ish Armor vs. Dexterity [Luke]"
+@269000 = "Alternate Concentration Check [Luke (EEex)]"
+@269001 = "v1 (check readme)"
+@269002 = "v2 (check readme)"
+@269003 = "v3 (check readme)"
+@269004 = "v4 (check readme)"
 
 @270000 = "Defensive Roll feat for Thieves [Luke]"
 

--- a/cdtweaks/languages/italian/concentration.tra
+++ b/cdtweaks/languages/italian/concentration.tra
@@ -1,0 +1,7 @@
+@0 = "Concentrazione (Successo)"
+@1 = "Livello dell'Incantesimo"
+//
+@2 = "Danno Subito"
+@3 = "Modificatore alla Costituzione"
+@4 = "Fortuna"
+@5 = "15"

--- a/cdtweaks/languages/italian/weidu.tra
+++ b/cdtweaks/languages/italian/weidu.tra
@@ -416,7 +416,11 @@ o rimpiazzata da - un'altra facente parte di uno dei mods installati.~
 
 @267000 = "Aggiungi talento Doppia-Presa per i Ranger [Luke]"
 
-@269000 = "Armatura vs. Destrezza in stile NWN [Luke]"
+@269000 = "Modifica la meccanica della Concentrazione [Luke (EEex)]"
+@269001 = "v1 (fare riferimento al readme)"
+@269002 = "v2 (fare riferimento al readme)"
+@269003 = "v3 (fare riferimento al readme)"
+@269004 = "v4 (fare riferimento al readme)"
 
 @270000 = "Aggiungi talento Tiro Difensivo per i ladri [Luke]"
 

--- a/cdtweaks/lib/comp_2691.tpa
+++ b/cdtweaks/lib/comp_2691.tpa
@@ -12,6 +12,6 @@ WITH_SCOPE BEGIN
   INCLUDE "cdtweaks\lib\concentration.tph"
   //
   WITH_TRA "cdtweaks\languages\english\concentration.tra" "cdtweaks\languages\%LANGUAGE%\concentration.tra" BEGIN
-    LAF "ALTERNATE_CONCENTRATION_CHECK" INT_VAR "version" = 0 END
+    LAF "ALTERNATE_CONCENTRATION_CHECK" INT_VAR "version" = 1 END
   END
 END

--- a/cdtweaks/lib/comp_2692.tpa
+++ b/cdtweaks/lib/comp_2692.tpa
@@ -12,6 +12,6 @@ WITH_SCOPE BEGIN
   INCLUDE "cdtweaks\lib\concentration.tph"
   //
   WITH_TRA "cdtweaks\languages\english\concentration.tra" "cdtweaks\languages\%LANGUAGE%\concentration.tra" BEGIN
-    LAF "ALTERNATE_CONCENTRATION_CHECK" INT_VAR "version" = 0 END
+    LAF "ALTERNATE_CONCENTRATION_CHECK" INT_VAR "version" = 2 END
   END
 END

--- a/cdtweaks/lib/comp_2693.tpa
+++ b/cdtweaks/lib/comp_2693.tpa
@@ -12,6 +12,6 @@ WITH_SCOPE BEGIN
   INCLUDE "cdtweaks\lib\concentration.tph"
   //
   WITH_TRA "cdtweaks\languages\english\concentration.tra" "cdtweaks\languages\%LANGUAGE%\concentration.tra" BEGIN
-    LAF "ALTERNATE_CONCENTRATION_CHECK" INT_VAR "version" = 0 END
+    LAF "ALTERNATE_CONCENTRATION_CHECK" INT_VAR "version" = 3 END
   END
 END

--- a/cdtweaks/lib/concentration.tph
+++ b/cdtweaks/lib/concentration.tph
@@ -1,0 +1,50 @@
+DEFINE_ACTION_FUNCTION "ALTERNATE_CONCENTRATION_CHECK"
+INT_VAR
+	"version" = "-1"
+BEGIN
+	OUTER_SET "feedback_strref_concentr_check" = RESOLVE_STR_REF (@0)
+	OUTER_SET "feedback_strref_spell_level" = RESOLVE_STR_REF (@1)
+	//
+	ACTION_MATCH "%version%" WITH
+		0 BEGIN
+			OUTER_TEXT_SPRINT "value1" "luck"
+			OUTER_TEXT_SPRINT "value2" "damageTaken"
+			OUTER_SET "feedback_strref_value1" = RESOLVE_STR_REF (@4)
+			OUTER_SET "feedback_strref_value2" = RESOLVE_STR_REF (@2)
+			//
+			LAF "APPEND_LUA_FUNCTION" STR_VAR "description" = "Misc Tweaks (Rule Changes)" "sourceFileSpec" = "cdtweaks\luke\lua\rule_changes\concentration.lua" "destRes" = "m_gtrule" END
+		END
+		1 BEGIN
+			OUTER_TEXT_SPRINT "value1" "conBonus"
+			OUTER_TEXT_SPRINT "value2" "15"
+			OUTER_SET "feedback_strref_value1" = RESOLVE_STR_REF (@3)
+			OUTER_SET "feedback_strref_value2" = RESOLVE_STR_REF (@5)
+			//
+			LAF "APPEND_LUA_FUNCTION" STR_VAR "description" = "Misc Tweaks (Rule Changes)" "sourceFileSpec" = "cdtweaks\luke\lua\rule_changes\concentration.lua" "destRes" = "m_gtrule" END
+		END
+		2 BEGIN
+			OUTER_TEXT_SPRINT "value1" "luck"
+			OUTER_TEXT_SPRINT "value2" "15"
+			OUTER_SET "feedback_strref_value1" = RESOLVE_STR_REF (@4)
+			OUTER_SET "feedback_strref_value2" = RESOLVE_STR_REF (@5)
+			//
+			LAF "APPEND_LUA_FUNCTION" STR_VAR "description" = "Misc Tweaks (Rule Changes)" "sourceFileSpec" = "cdtweaks\luke\lua\rule_changes\concentration.lua" "destRes" = "m_gtrule" END
+		END
+		3 BEGIN
+			OUTER_TEXT_SPRINT "value1" "conBonus"
+			OUTER_TEXT_SPRINT "value2" "damageTaken"
+			OUTER_SET "feedback_strref_value1" = RESOLVE_STR_REF (@3)
+			OUTER_SET "feedback_strref_value2" = RESOLVE_STR_REF (@2)
+			//
+			LAF "APPEND_LUA_FUNCTION" STR_VAR "description" = "Misc Tweaks (Rule Changes)" "sourceFileSpec" = "cdtweaks\luke\lua\rule_changes\concentration.lua" "destRes" = "m_gtrule" END
+		END
+		DEFAULT
+			FAIL "Should not happen"
+	END
+	//
+	LAF "APPEND_LUA_FUNCTION" STR_VAR "description" = "Utility" "sourceFileSpec" = "cdtweaks\luke\lua\utility\decode_spell.lua" "destRes" = "m_gtutil" END
+	//
+	COPY "cdtweaks\luke\2da\alternate_concentration_check.2da" "override\concentr.2da"
+		PRETTY_PRINT_2DA
+	BUT_ONLY
+END

--- a/cdtweaks/luke/2da/alternate_concentration_check.2da
+++ b/cdtweaks/luke/2da/alternate_concentration_check.2da
@@ -1,0 +1,4 @@
+2DA V1.0
+0
+BEHAVIOR                 VALUE
+CHECK_MODE               EEex-LuaFunction=cdtweaks_AlterConcentrationCheck

--- a/cdtweaks/luke/lua/rule_changes/concentration.lua
+++ b/cdtweaks/luke/lua/rule_changes/concentration.lua
@@ -1,0 +1,55 @@
+--[[
++---------------------------------------------------------------------+
+| cdtweaks, alternate concentration check (fix bugged "CONCENTR.2DA") |
++---------------------------------------------------------------------+
+--]]
+
+local function cdtweaks_AlterConcentrationCheck_DisplaySpriteMessage(sprite, messageStr)
+
+	local message = EEex_NewUD("CMessageDisplayText")
+
+	EEex_RunWithStackManager({
+		{ ["name"] = "messageStr", ["struct"] = "CString", ["constructor"] = {["args"] = {messageStr} } } },
+		function(manager)
+			local id = sprite.m_id
+			message:Construct(sprite:GetName(true), manager:getUD("messageStr"), 0xBED7D7, 0xBED7D7, -1, id, id)
+		end
+	)
+
+	EngineGlobals.g_pBaldurChitin.m_cMessageHandler:AddMessage(message, false);
+end
+
+function cdtweaks_AlterConcentrationCheck(sprite, damageData)
+
+	local curAction = sprite.m_curAction
+
+	-- Get the spell that is currently being cast
+	local spellResRef = curAction.m_string1.m_pchData:get()
+	if spellResRef == "" then
+		spellResRef = GT_Utility_DecodeSpell(curAction.m_specificID)
+	end
+	local spellLevel = EEex_Resource_Demand(spellResRef, "SPL").spellLevel
+
+	-- Fetch components of check
+	local roll = math.random(20) - 1
+	local luck = sprite:getActiveStats().m_nLuck
+	local con = sprite:getActiveStats().m_nCON
+	local conBonus = math.floor(con / 2) - 5
+	local damageTaken = damageData.damageTaken
+
+	-- Do check
+	local casterRoll = roll + %value1%
+	local attackerRoll = spellLevel + %value2%
+	local disrupted = casterRoll <= attackerRoll
+
+	-- Feedback
+	if not disrupted then
+		cdtweaks_AlterConcentrationCheck_DisplaySpriteMessage(sprite,
+			string.format("%s : %d > %d : [%d (1d20 - 1) + %d (%s)] > [%d (%s) + %d (%s)]",
+			Infinity_FetchString(%feedback_strref_concentr_check%), casterRoll, attackerRoll, roll, %value1%, Infinity_FetchString(%feedback_strref_value1%), spellLevel, Infinity_FetchString(%feedback_strref_spell_level%), %value2%, Infinity_FetchString(%feedback_strref_value2%))
+		)
+	end
+
+	-- Return interruption result
+	return disrupted
+end

--- a/cdtweaks/readme-cdtweaks.html
+++ b/cdtweaks/readme-cdtweaks.html
@@ -1011,22 +1011,18 @@
       <p> <strong>Dual-Wield feat for Rangers [Luke]</strong><br />
         <em><abbr title="Enhanced Edition">EEex</abbr></em></p>
       <p> This component simply forces Rangers to wield light armors (or no armor) in order to benefit from Two-Weapon Fighting.</p>
-      <p> <strong>NWN-ish Armor vs. Dexterity [Luke]</strong><br />
+      <p> <strong>Alternate Concentration Check [Luke]</strong><br />
         <em><abbr title="Enhanced Edition">EEex</abbr></em></p>
-      <p> This component simply &quot;forces&quot; characters to wield light armors (or no armor) if they have high Dexterity.
-        In particular: </p>
-      <ul>
-        <li>If a character is equipped with a Medium Armor, it will only benefit from half the bonus derived from its Dexterity (see <a href="https://gibberlings3.github.io/iesdp/files/2da/2da_bgee/dexmod.htm"><code>dexmod.2da</code></a>)
-          <ul>
-            <li>So for instance, a character with <code>18</code> DEX equipped with a Chain Mail Armor will suffer a <code>-4 / 2 = -2</code> AC penalty.</li>
-          </ul>
-        </li>
-        <li>If a character is equipped with a Heavy Armor, it will not benefit from the bonus derived from its Dexterity (see <a href="https://gibberlings3.github.io/iesdp/files/2da/2da_bgee/dexmod.htm"><code>dexmod.2da</code></a>)
-          <ul>
-            <li>So for instance, a character with <code>18</code> DEX equipped with a Plate Mail will suffer a <code>-4</code> AC penalty.</li>
-          </ul>
-        </li>
-      </ul>
+      <p>
+        By default, any damage a spellcaster takes will cause them to fail their spellcasting.
+        This component alters this mechanic and comes into four different variants:
+        <ol>
+          <li>Spell disrupted if <code>(1d20 - 1) + Luck &le; Spell Level + Damage Taken</code></li>
+          <li>Spell disrupted if <code>(1d20 - 1) + &lfloor;(Constitution / 2)&rfloor; - 5 &le; Spell Level + 15</code></li>
+          <li>Spell disrupted if <code>(1d20 - 1) + Luck &le; Spell Level + 15</code></li>
+          <li>Spell disrupted if <code>(1d20 - 1) + &lfloor;(Constitution / 2)&rfloor; - 5 &le; Spell Level + Damage Taken</code></li>
+        </ol>
+      </p>
       <p> <strong>Defensive Roll feat for Thieves [Luke]</strong><br />
         <em><abbr title="Enhanced Edition">EEex</abbr></em></p>
       <p> This component aims at implementing the NWN feat Defensive Roll. As a result, after installing it, if the character is struck by a potentially lethal blow, he makes a Save vs. Breath. If successful, he takes only half damage from the blow.</p>

--- a/cdtweaks/setup-cdtweaks.tp2
+++ b/cdtweaks/setup-cdtweaks.tp2
@@ -2853,16 +2853,58 @@ LABEL ~cd_tweaks_revised_archer~
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////                                                            \\\\\
-///// NWN-ish Armor vs. Dexterity                                \\\\\
+///// Alternate concentration checks                             \\\\\
 /////                                                            \\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 
-BEGIN @269000 DESIGNATED 2690
+/////                                                            \\\\\
+///// (1d20 - 1) + Luck <= Spell Level + Damage Taken            \\\\\
+/////                                                            \\\\\
+
+BEGIN @269001 DESIGNATED 2690
 GROUP @9
+SUBCOMPONENT @269000
 REQUIRE_PREDICATE MOD_IS_INSTALLED ~EEex.tp2~ 0 @29
-REQUIRE_PREDICATE FILE_EXISTS ~cdtweaks/languages/%LANGUAGE%/nwn-ish_armor_vs_dex.tra~ @7
-LABEL ~cd_tweaks_nwn-ish_armor_vs_dex~
+REQUIRE_PREDICATE GAME_IS "bgee bg2ee eet iwdee" @25
+REQUIRE_PREDICATE FILE_EXISTS ~cdtweaks/languages/%LANGUAGE%/concentration.tra~ @7
+LABEL ~cd_tweaks_alternate_concentration_check_v1~
+
+/////                                                            \\\\\
+///// (1d20 - 1) + (Constitution / 2) - 5 <= Spell Level + 15    \\\\\
+/////                                                            \\\\\
+
+BEGIN @269002 DESIGNATED 2691
+GROUP @9
+SUBCOMPONENT @269000
+REQUIRE_PREDICATE MOD_IS_INSTALLED ~EEex.tp2~ 0 @29
+REQUIRE_PREDICATE GAME_IS "bgee bg2ee eet iwdee" @25
+REQUIRE_PREDICATE FILE_EXISTS ~cdtweaks/languages/%LANGUAGE%/concentration.tra~ @7
+LABEL ~cd_tweaks_alternate_concentration_check_v2~
+
+/////                                                            \\\\\
+///// (1d20 - 1) + Luck <= Spell Level + 15                      \\\\\
+/////                                                            \\\\\
+
+BEGIN @269003 DESIGNATED 2692
+GROUP @9
+SUBCOMPONENT @269000
+REQUIRE_PREDICATE MOD_IS_INSTALLED ~EEex.tp2~ 0 @29
+REQUIRE_PREDICATE GAME_IS "bgee bg2ee eet iwdee" @25
+REQUIRE_PREDICATE FILE_EXISTS ~cdtweaks/languages/%LANGUAGE%/concentration.tra~ @7
+LABEL ~cd_tweaks_alternate_concentration_check_v3~
+
+/////                                                                        \\\\\
+///// (1d20 - 1) + (Constitution / 2) - 5 <= Spell Level + Damage Taken      \\\\\
+/////                                                                        \\\\\
+
+BEGIN @269004 DESIGNATED 2693
+GROUP @9
+SUBCOMPONENT @269000
+REQUIRE_PREDICATE MOD_IS_INSTALLED ~EEex.tp2~ 0 @29
+REQUIRE_PREDICATE GAME_IS "bgee bg2ee eet iwdee" @25
+REQUIRE_PREDICATE FILE_EXISTS ~cdtweaks/languages/%LANGUAGE%/concentration.tra~ @7
+LABEL ~cd_tweaks_alternate_concentration_check_v4~
 
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\


### PR DESCRIPTION
By default, any damage a spellcaster takes will cause them to fail their spellcasting.
This component alters this mechanic and comes into four different variants:

1. Spell disrupted if <code>(1d20 - 1) + Luck &le; Spell Level + Damage Taken</code>
2. Spell disrupted if <code>(1d20 - 1) + &lfloor;(Constitution / 2)&rfloor; - 5 &le; Spell Level + 15</code>
3. Spell disrupted if <code>(1d20 - 1) + Luck &le; Spell Level + 15</code>
4. Spell disrupted if <code>(1d20 - 1) + &lfloor;(Constitution / 2)&rfloor; - 5 &le; Spell Level + Damage Taken</code>