### PR TITLE
SoA compatibility fix for "Adjust Nalia's Thief level" component

### DIFF
--- a/cdtweaks/lib/nalia_thief_levels.tph
+++ b/cdtweaks/lib/nalia_thief_levels.tph
@@ -8,12 +8,14 @@ BEGIN
   OUTER_SPRINT src_path ~cdtweaks/cre/%folder_prefix%%level%~
   ACTION_IF (DIRECTORY_EXISTS ~%src_path%~) BEGIN
     ACTION_FOR_EACH cre_resref IN ~nalia8~ ~nalia10~ ~nalia11~ ~nalia13~ ~nalia15~ ~nalia18~ BEGIN
-      COPY_EXISTING ~%cre_resref%.cre~ ~override~
-        LPF a7#fetch_cre_attributes RET_ARRAY cre_numbers cre_strings END
-      BUT_ONLY
+      ACTION_IF (FILE_EXISTS_IN_GAME ~%cre_resref%.cre~) BEGIN
+        COPY_EXISTING ~%cre_resref%.cre~ ~override~
+          LPF a7#fetch_cre_attributes RET_ARRAY cre_numbers cre_strings END
+        BUT_ONLY
 
-      COPY ~%src_path%/%cre_resref%.cre~ ~override~
-        LPF a7#apply_cre_attributes END
+        COPY ~%src_path%/%cre_resref%.cre~ ~override~
+          LPF a7#apply_cre_attributes END
+      END
     END
   END ELSE BEGIN
     WARN ~Unsupported creature level: %level%~


### PR DESCRIPTION
Fixes installation issues on original BG2:SoA installations.