### PR TITLE
Tweak component: Limit resting mechanic

### DIFF
--- a/cdtweaks/lib/gt_limit_resting_mechanic.tph
+++ b/cdtweaks/lib/gt_limit_resting_mechanic.tph
@@ -7,6 +7,8 @@ BEGIN
 		//
 	END
 	//
+	LAF "APPEND_LUA_CHUNK" STR_VAR "description" = "Rule Changes" "sourceFileSpec" = "cdtweaks\luke\lua\rule_changes\override_heal_on_rest.lua" "destRes" = "m_gtrule" END
+	//
 	<<<<<<<< .../cdtweaks-inlined/limit_resting_mechanic.baf
 	IF
 		PartyRested()

--- a/cdtweaks/lib/gt_limit_resting_mechanic.tph
+++ b/cdtweaks/lib/gt_limit_resting_mechanic.tph
@@ -1,6 +1,28 @@
 DEFINE_ACTION_FUNCTION "LIMIT_RESTING_MECHANIC"
 BEGIN
-	OUTER_SET "feedback_strref" = RESOLVE_STR_REF (@0)
+	WITH_SCOPE BEGIN
+		OUTER_SET "feedback_strref" = RESOLVE_STR_REF (@0)
+		//
+		LAF "APPEND_LUA_CHUNK" STR_VAR "description" = "Rule Changes" "sourceFileSpec" = "cdtweaks\luke\lua\rule_changes\limit_resting_mechanic.lua" "destRes" = "m_gtrule" END
+		//
+	END
 	//
-	LAF "APPEND_LUA_CHUNK" STR_VAR "description" = "Rule Changes" "sourceFileSpec" = "cdtweaks\luke\lua\rule_changes\limit_resting_mechanic.lua" "destRes" = "m_gtrule" END
+	<<<<<<<< .../cdtweaks-inlined/limit_resting_mechanic.baf
+	IF
+		PartyRested()
+		EEex_LuaTrigger("GT_TweaksAnthology_LimitRestingMechanic(0x1)")
+	THEN
+		RESPONSE #100
+			EEex_LuaAction("GT_TweaksAnthology_LimitRestingMechanic(0x2)")
+			Continue()
+	END
+	>>>>>>>>
+	// getting and patching list of world scripts
+	LAF "GET_WORLD_SCRIPTS" RET_ARRAY "world_scripts" = "toReturn" END
+	ACTION_PHP_EACH "world_scripts" AS "resref" => "" BEGIN
+		ACTION_IF (FILE_EXISTS_IN_GAME "%resref%.bcs") BEGIN
+			EXTEND_TOP "%resref%.bcs" ".../cdtweaks-inlined/limit_resting_mechanic.baf"
+		END
+	END
 END
+

--- a/cdtweaks/lib/gt_limit_resting_mechanic.tph
+++ b/cdtweaks/lib/gt_limit_resting_mechanic.tph
@@ -10,7 +10,7 @@ BEGIN
 	<<<<<<<< .../cdtweaks-inlined/limit_resting_mechanic.baf
 	IF
 		PartyRested()
-		EEex_LuaTrigger("GT_TweaksAnthology_LimitRestingMechanic(0x1)")
+		EEex_LuaTrigger("return GT_TweaksAnthology_LimitRestingMechanic(0x1)")
 	THEN
 		RESPONSE #100
 			EEex_LuaAction("GT_TweaksAnthology_LimitRestingMechanic(0x2)")

--- a/cdtweaks/luke/lib/weidu/get_world_scripts.tph
+++ b/cdtweaks/luke/lib/weidu/get_world_scripts.tph
@@ -1,0 +1,29 @@
+/*
++----------------------------------------------------------------------------------------+
+| GET_WORLD_SCRIPTS                                                                      |
++----------------------------------------------------------------------------------------+
+| Retrieves the list of world scripts in the game                                        |
++----------------------------------------------------------------------------------------+
+*/
+
+DEFINE_DIMORPHIC_FUNCTION "GET_WORLD_SCRIPTS"
+RET_ARRAY
+	"toReturn"
+BEGIN
+	// default list of world scripts
+	ACTION_DEFINE_ASSOCIATIVE_ARRAY "toReturn" BEGIN
+		"baldur" => 1
+		"baldur25" => 1
+		"bdbaldur" => 1
+	END
+	// from campaign.2da
+	COPY_EXISTING - ~campaign.2da~ ~override~
+		COUNT_2DA_COLS "cols"
+		READ_2DA_ENTRIES_NOW "table" "%cols%"
+		FOR ("row" = 0; "%row%" < "%table%"; "row" += 1) BEGIN
+			READ_2DA_ENTRY_FORMER "table" "%row%" 1 "resref"
+			SET $"toReturn"(~%resref%~) = 1
+		END
+	BUT_ONLY IF_EXISTS
+END
+

--- a/cdtweaks/luke/lua/rule_changes/limit_resting_mechanic.lua
+++ b/cdtweaks/luke/lua/rule_changes/limit_resting_mechanic.lua
@@ -2,26 +2,50 @@
 +------------------------------------------------------------------------------+
 | cdtweaks, Limit resting mechanic (at most once every 24 in-game hours)       |
 +------------------------------------------------------------------------------+
-| scripted resting will not be blocked; however, it will still reset the timer |
+| scripted resting will not be blocked!                                        |
 +------------------------------------------------------------------------------+
 --]]
 
-EEex_Action_AddSpriteStartedActionListener(function(sprite, action)
-	if sprite.m_typeAI.m_EnemyAlly == 2 and action.m_actionID == 96 then -- if [PC] and "Rest()"
-		sprite:applyEffect({
-			["effectID"] = 0x141, -- Remove effects by resource (321)
-			["res"] = "GTRULE01",
-			["sourceID"] = sprite.m_id,
-			["sourceTarget"] = sprite.m_id,
-		})
-		--
-		sprite:applyEffect({
-			["effectID"] = 0x152, -- Disable rest or save (338)
-			["effectAmount"] = %feedback_strref%,
-			["duration"] = 7200,
-			["m_sourceRes"] = "GTRULE01",
-			["sourceID"] = sprite.m_id,
-			["sourceTarget"] = sprite.m_id,
-		})
+function GT_TweaksAnthology_LimitRestingMechanic(mode)
+	if mode == 0x1 then -- script trigger
+		local toReturn = true
+		for i = 0, 5 do
+			local partyMember = EEex_Sprite_GetInPortrait(i) -- CGameSprite
+			if partyMember then -- sanity check
+				EEex_Utility_IterateCPtrList(partyMember.m_timedEffectList, function(effect) -- CGameEffect
+					if effect.m_sourceRes:get() == "GTRULE01" then
+						if effect.m_effectId == 0x152 then -- Disable rest or save (338)
+							toReturn = false
+							return true -- break loop
+						end
+					end
+				end)
+				if not toReturn then break end -- break loop
+			end
+		end
+		return toReturn
+	elseif mode == 0x2 then -- script action
+		for i = 0, 5 do
+			local partyMember = EEex_Sprite_GetInPortrait(i) -- CGameSprite
+			if partyMember then -- sanity check
+				partyMember:applyEffect({
+					["effectID"] = 0x141, -- Remove effects by resource (321)
+					["res"] = "GTRULE01",
+					["noSave"] = true, -- just in case...
+					["sourceID"] = partyMember.m_id,
+					["sourceTarget"] = partyMember.m_id,
+				})
+				--
+				partyMember:applyEffect({
+					["effectID"] = 0x152, -- Disable rest or save (338)
+					["effectAmount"] = %feedback_strref%,
+					["duration"] = 7200,
+					["m_sourceRes"] = "GTRULE01",
+					["noSave"] = true, -- just in case...
+					["sourceID"] = partyMember.m_id,
+					["sourceTarget"] = partyMember.m_id,
+				})
+			end
+		end
 	end
-end)
+end

--- a/cdtweaks/luke/lua/rule_changes/limit_resting_mechanic.lua
+++ b/cdtweaks/luke/lua/rule_changes/limit_resting_mechanic.lua
@@ -39,7 +39,7 @@ function GT_TweaksAnthology_LimitRestingMechanic(mode)
 				partyMember:applyEffect({
 					["effectID"] = 0x152, -- Disable rest or save (338)
 					["effectAmount"] = %feedback_strref%,
-					["duration"] = 7200,
+					["duration"] = 4800, -- SIXTEEN_HOURS (as per gtimes.ids)
 					["m_sourceRes"] = "GTRULE01",
 					["noSave"] = true, -- just in case...
 					["sourceID"] = partyMember.m_id,

--- a/cdtweaks/luke/lua/rule_changes/override_heal_on_rest.lua
+++ b/cdtweaks/luke/lua/rule_changes/override_heal_on_rest.lua
@@ -1,0 +1,32 @@
+--[[
++-----------------------------------------------+
+| cdtweaks, override game option 'HEAL_ON_REST' |
++-----------------------------------------------+
+--]]
+
+EEex_GameState_AddInitializedListener(function()
+	-- get option_id
+	local option_id
+	local panel_id = 8
+	for _, v in ipairs(toggleTitles) do
+		if v[1] == "HEAL_ON_REST_LABEL" then
+			option_id = v[3]
+			break
+		end
+	end
+	if not option_id then
+		EEex_Error("option_id for HEAL_ON_REST_LABEL not found!")
+	end
+	-- CBaldurEngine
+	local old = CBaldurEngine.OnRestButtonClick
+	CBaldurEngine.OnRestButtonClick = function(...)
+		Infinity_ChangeOption(option_id, 0, panel_id)
+		old(...)
+	end
+	-- CScreenStore
+	local old = CScreenStore.OnRentRoomButtonClick
+	CScreenStore.OnRentRoomButtonClick = function(...)
+		Infinity_ChangeOption(option_id, 0, panel_id)
+		old(...)
+	end
+end)

--- a/cdtweaks/readme-cdtweaks.html
+++ b/cdtweaks/readme-cdtweaks.html
@@ -1080,7 +1080,12 @@ div.quote {
       <p>Black bears are unaffected by this tweak. Spells such as Finger of Death or Power Word, Kill can still immediately slay the creature. </p>
       <p> <a id="contents_2670" name="contents_2670"></a><strong>Limit Resting Mechanic [Luke]</strong> <a href="#contents_2670" rel=""><img alt="Link to this component" height="9" width="14" src="style/link.png" /></a><br />
         <em>EEex required; available for <abbr title="Baldur's Gate: Enhanced Edition">BGEE</abbr>, <abbr title="Baldur's Gate II: Enhanced Edition">BG2EE</abbr>, <abbr title="Icewind Dale: Enhanced Edition">IWDEE</abbr>, <abbr title="Enhanced Edition Trilogy">EET</abbr></em></p>
-      <p> This component simply forces the party to rest at most once per 24 in-game hours. It does not prevent scripted resting. </p>
+      <p>
+        This component simply forces the party to rest at most once per 24 in-game hours. It does not prevent scripted resting.
+        <div class="quote">
+          <p>This tweak will also automatically disable Gameplay Option &quot;Rest Until Healed&quot; right before starting resting.</p>
+        </div>
+      </p>
       <p> <a id="contents_2680" name="contents_2680"></a><strong>Make Infravision Useful [Luke]</strong> <a href="#contents_2680" rel=""><img alt="Link to this component" height="9" width="14" src="style/link.png" /></a><br />
         <em>EEex required; available for <abbr title="Baldur's Gate: Enhanced Edition">BGEE</abbr>, <abbr title="Baldur's Gate II: Enhanced Edition">BG2EE</abbr>, <abbr title="Icewind Dale: Enhanced Edition">IWDEE</abbr>, <abbr title="Enhanced Edition Trilogy">EET</abbr></em></p>
       <p> All creatures without the Infravision ability will incur a -4 penalty to <abbr title="To-Hit Armor Class 0">THAC0</abbr> in darkness (dungeon or night areas), as per <abbr title="Advanced Dungeons &amp; Dragons">AD&amp;D</abbr> rules.  This rule change only applies to playable races.</p>


### PR DESCRIPTION
Make sure the timer does not trigger when rest is interrupted (f.i. when resting illegally within city limits or when enemies attack).